### PR TITLE
Improvements to PythonJSON structure

### DIFF
--- a/src/qilib/utils/python_json_structure.py
+++ b/src/qilib/utils/python_json_structure.py
@@ -28,7 +28,7 @@ class PythonJsonStructure(dict):
     def __init__(self, *args, **kwargs):
         """ A python container which can hold data objects and can be serialized
             into JSON. Currently the following data types can be added to the
-            container object: bool, bytes, int, float, list, tuple, dict
+            container object: bool, bytes, int, float, list, tuple, dict,
             PythonJsonStructure and numpy arrays. The PythonJsonStructure is a
             dictionary with similar calling methods, but with some
             limitations/restrictions.

--- a/src/qilib/utils/python_json_structure.py
+++ b/src/qilib/utils/python_json_structure.py
@@ -111,6 +111,8 @@ class PythonJsonStructure(dict):
         return isinstance(data, PythonJsonStructure.__serializable_container_types)
 
     def __check_serializability_ndarray(self, data):
+        if data.dtype in (bool, int, float, np.int32, np.float32, np.float64):
+            return True
         return_data = np.empty_like(data)
         for index in np.ndindex(data.shape):
             return_data[index] = self.__check_serializability(data[index])

--- a/src/qilib/utils/python_json_structure.py
+++ b/src/qilib/utils/python_json_structure.py
@@ -112,7 +112,7 @@ class PythonJsonStructure(dict):
 
     def __check_serializability_ndarray(self, data):
         if data.dtype in (bool, int, float, np.int32, np.float32, np.float64):
-            return True
+            return data
         return_data = np.empty_like(data)
         for index in np.ndindex(data.shape):
             return_data[index] = self.__check_serializability(data[index])

--- a/src/tests/unittests/utils/test_python_json_structure.py
+++ b/src/tests/unittests/utils/test_python_json_structure.py
@@ -211,3 +211,14 @@ class TestPythonJsonStructure(unittest.TestCase):
             serialized_object = serialize(json_object)
             unserialized_object = unserialize(serialized_object)
             np.testing.assert_equal(json_object, unserialized_object)
+
+    def test_storage_numpy_array(self):
+        json_object = PythonJsonStructure()
+        large_numpy_array = np.zeros((10000, 2000, 3))
+        json_object['array'] = large_numpy_array
+        self.assertIsInstance(json_object['array'], np.ndarray)
+
+    def test_boolean_numpy_array(self):
+        json_object = PythonJsonStructure()
+        json_object['boolean_array'] = np.array([True, False])
+        self.assertEqual(json_object['boolean_array'].dtype, bool)


### PR DESCRIPTION
* Make check on serializability of numpy arrays faster
* Allow boolean numpy arrays in PythonJSON structure

@quantumkoen 