### PR TITLE
[DEM- 937] Improve reporting of None settings in CommonInstrumentAdapter

### DIFF
--- a/src/qilib/configuration_helper/adapters/common_config_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/common_config_instrument_adapter.py
@@ -43,6 +43,7 @@ class CommonConfigInstrumentAdapter(InstrumentAdapter, ABC):
 
         for parameter in config:
             if parameter in self._instrument.parameters and hasattr(self._instrument.parameters[parameter], 'set'):
+
                 result = self._compare_config_values(config[parameter]['value'],
                                                      device_config[parameter]['value'], parameter)
                 if result:

--- a/src/qilib/configuration_helper/adapters/common_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/common_instrument_adapter.py
@@ -17,9 +17,8 @@ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEM
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-import logging
 from abc import ABC, abstractmethod
-from typing import List
+from typing import Any, Dict, List
 
 from qilib.configuration_helper import InstrumentAdapter
 from qilib.utils import PythonJsonStructure
@@ -32,8 +31,8 @@ class CommonInstrumentAdapter(InstrumentAdapter, ABC):
 
         Only the setter commands will be updated.
         Note that setter only parameters which have not been set yield a None when reading the configuration from the
-        instrument adapter. These None parameter values in the configuration will not be set. A warning will be
-        given if any of the configuration parameter values are None.
+        instrument adapter. The apply method will raise a ValueError if any of the configuration parameter values are
+        None. The None value parameters are listed in the raised ValueError.
 
         Args:
             config: The configuration with settings for the adapters instrument.
@@ -62,14 +61,14 @@ class CommonInstrumentAdapter(InstrumentAdapter, ABC):
                                  parameters which are filtered out by this function.
         """
 
-    def __raise_none_value_parameters(self, config: PythonJsonStructure, parameters: List[dict]) -> None:
-        """ Raises a ValueError when in the configuration one or more parameters have value None.
+    def __raise_none_value_parameters(self, config: PythonJsonStructure, parameters: List[Dict[str, Any]]) -> None:
+        """ Raises a ValueError when one or more parameters in the configuration have value None.
 
         Args:
-            config: The configuration with settings for the adapters instrument.
-            parameters: A list of the settable parameters of the instrument.
+            config: A configuration with settings for the instrument adapter.
+            parameters: A list with settable instrument parameters.
         """
-        none_value_parameters = list(filter(lambda parameter: config[parameter]['value']==None, parameters))
+        none_value_parameters = list(filter(lambda parameter: config[parameter]['value'] is None, parameters))
         if none_value_parameters:
             error_message = f'The following parameter(s) of {self._instrument.name} have value ' \
                             f'None and cannot be set: {none_value_parameters}!'

--- a/src/qilib/configuration_helper/adapters/common_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/common_instrument_adapter.py
@@ -61,7 +61,7 @@ class CommonInstrumentAdapter(InstrumentAdapter, ABC):
                                  parameters which are filtered out by this function.
         """
 
-    def __raise_none_value_parameters(self, config: PythonJsonStructure, parameters: List[Dict[str, Any]]) -> None:
+    def __raise_none_value_parameters(self, config: PythonJsonStructure, parameters: List[PythonJsonStructure]) -> None:
         """ Raises a ValueError when one or more parameters in the configuration have value None.
 
         Args:

--- a/src/qilib/configuration_helper/adapters/common_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/common_instrument_adapter.py
@@ -63,14 +63,14 @@ class CommonInstrumentAdapter(InstrumentAdapter, ABC):
         """
 
     def __raise_none_value_parameters(self, config: PythonJsonStructure, parameters: List[dict]) -> None:
-        """ Raises a ValueError if non value parameters are present in the configuration.
+        """ Raises a ValueError when in the configuration one or more parameters have value None.
 
         Args:
             config: The configuration with settings for the adapters instrument.
             parameters: A list of the settable parameters of the instrument.
         """
-        non_value_parameters = list(filter(lambda parameter: config[parameter]['value']==None, parameters))
-        if non_value_parameters:
+        none_value_parameters = list(filter(lambda parameter: config[parameter]['value']==None, parameters))
+        if none_value_parameters:
             error_message = f'The following parameter(s) of {self._instrument.name} have value ' \
-                            f'None and cannot be set: {non_value_parameters}!'
+                            f'None and cannot be set: {none_value_parameters}!'
             raise ValueError(error_message)

--- a/src/qilib/configuration_helper/adapters/common_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/common_instrument_adapter.py
@@ -65,11 +65,7 @@ class CommonInstrumentAdapter(InstrumentAdapter, ABC):
         """
         """
         non_value_parameters = list(filter(lambda parameter: config[parameter]['value']==None, parameters))
-        if not non_value_parameters:
-            return
-
-        error_message = f'The following parameter(s) of {self._instrument.name} have value None and cannot be set: '
-        for parameter in non_value_parameters[:-1]:
-            error_message += f'{parameter}, '
-        error_message += f'{non_value_parameters[-1]}!'
-        raise ValueError(error_message)
+        if non_value_parameters:
+            error_message = f'The following parameter(s) of {self._instrument.name} have value ' \
+                            f'None and cannot be set: {non_value_parameters}!'
+            raise ValueError(error_message)

--- a/src/qilib/configuration_helper/adapters/common_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/common_instrument_adapter.py
@@ -42,12 +42,9 @@ class CommonInstrumentAdapter(InstrumentAdapter, ABC):
             if parameter in self._instrument.parameters and hasattr(self._instrument.parameters[parameter], 'set'):
                 parameters.append(parameter)
 
-        if any(config[parameter]['value'] is None for parameter in parameters):
-            error_message = 'Some parameter values of {0} are None and will not be set!'.format(self._instrument.name)
-            logging.warning(error_message)
+        self.__raise_none_value_parameters(config, parameters)
         for parameter in parameters:
-            if 'value' in config[parameter] and config[parameter]['value'] is not None:
-                self._instrument.set(parameter, config[parameter]['value'])
+            self._instrument.set(parameter, config[parameter]['value'])
 
     @abstractmethod
     def _filter_parameters(self, parameters: PythonJsonStructure) -> PythonJsonStructure:
@@ -63,3 +60,16 @@ class CommonInstrumentAdapter(InstrumentAdapter, ABC):
             PythonJsonStructure: Contains the instrument snapshot without the instrument
                                  parameters which are filtered out by this function.
         """
+
+    def __raise_none_value_parameters(self, config, parameters) -> None:
+        """
+        """
+        non_value_parameters = list(filter(lambda parameter: config[parameter]['value']==None, parameters))
+        if not non_value_parameters:
+            return
+
+        error_message = f'The following parameter(s) of {self._instrument.name} have value None and cannot be set: '
+        for parameter in non_value_parameters[:-1]:
+            error_message += f'{parameter}, '
+        error_message += f'{non_value_parameters[-1]}!'
+        raise ValueError(error_message)

--- a/src/qilib/configuration_helper/adapters/common_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/common_instrument_adapter.py
@@ -19,6 +19,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 """
 import logging
 from abc import ABC, abstractmethod
+from typing import List
 
 from qilib.configuration_helper import InstrumentAdapter
 from qilib.utils import PythonJsonStructure
@@ -61,8 +62,12 @@ class CommonInstrumentAdapter(InstrumentAdapter, ABC):
                                  parameters which are filtered out by this function.
         """
 
-    def __raise_none_value_parameters(self, config, parameters) -> None:
-        """
+    def __raise_none_value_parameters(self, config: PythonJsonStructure, parameters: List[dict]) -> None:
+        """ Raises a ValueError if non value parameters are present in the configuration.
+
+        Args:
+            config: The configuration with settings for the adapters instrument.
+            parameters: A list of the settable parameters of the instrument.
         """
         non_value_parameters = list(filter(lambda parameter: config[parameter]['value']==None, parameters))
         if non_value_parameters:

--- a/src/qilib/configuration_helper/instrument_adapter.py
+++ b/src/qilib/configuration_helper/instrument_adapter.py
@@ -105,7 +105,7 @@ class InstrumentAdapter(ABC):
         """
         visitor.visit(self)
 
-    def __notify_and_remove_none_values(self, snapshot: Dict[str, Any]) -> Dict[str, Any]:
+    def __notify_and_remove_none_values(self, snapshot: PythonJsonStructure) -> PythonJsonStructure:
         """ Return parameters from the QCoDeS snapshot which are not None.
 
             Takes the parameters of the QCoDeS instrument snapshot. Removes all parameters
@@ -119,8 +119,8 @@ class InstrumentAdapter(ABC):
             PythonJsonStructure: Contains the instrument snapshot parameters without the
                                  instrument parameters which a none value.
         """
-        parameters = {}
-        non_value_parameters = {}
+        parameters = PythonJsonStructure()
+        non_value_parameters = PythonJsonStructure()
         for parameter_name, settings in snapshot['parameters'].items():
             if 'value' in settings and settings['value'] is None:
                 non_value_parameters[parameter_name] = settings

--- a/src/qilib/configuration_helper/instrument_adapter.py
+++ b/src/qilib/configuration_helper/instrument_adapter.py
@@ -129,7 +129,7 @@ class InstrumentAdapter(ABC):
 
         if non_value_parameters:
             parameter_names = list(non_value_parameters.keys())
-            error_message = f'Parameter values of {self._instrument_name} are None. Please set: {parameter_names}'
+            error_message = f'Parameter values of {self._instrument_name} are None. Please set: {parameter_names}.'
             logging.error(error_message)
 
         return parameters

--- a/src/qilib/configuration_helper/instrument_adapter.py
+++ b/src/qilib/configuration_helper/instrument_adapter.py
@@ -66,8 +66,8 @@ class InstrumentAdapter(ABC):
         """ Obtains a full set of settings from the instrument.
 
         Returns:
-            Part of the instrument snapshot, i.e., parameter values, without the instrument's parameters which are
-            explicitly filtered out, and the instrument name.
+            Part of the instrument snapshot, i.e., parameter values, without the instrument's
+            parameters which are explicitly filtered out, and the instrument name.
         """
         configuration = PythonJsonStructure()
         if self._instrument is not None:

--- a/src/qilib/configuration_helper/instrument_adapter.py
+++ b/src/qilib/configuration_helper/instrument_adapter.py
@@ -19,7 +19,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 """
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, Any
+from typing import Any, Dict, Optional
 
 from qcodes import Instrument
 
@@ -29,7 +29,7 @@ from qilib.utils import PythonJsonStructure
 
 class InstrumentAdapter(ABC):
 
-    def __init__(self, address: str, instrument_name: str = None) -> None:
+    def __init__(self, address: str, instrument_name: Optional[str] = None) -> None:
         """ A template for an adapter to the QCoDeS instrument interface.
 
         Args:
@@ -106,10 +106,10 @@ class InstrumentAdapter(ABC):
         visitor.visit(self)
 
     def __notify_and_remove_none_values(self, snapshot: Dict[str, Any]) -> Dict[str, Any]:
-        """ Gets all setted parameters from the QCoDeS snapshot.
+        """ Return parameters from the QCoDeS snapshot which are not None.
 
             Takes the parameters of the QCoDeS instrument snapshot. Removes all parameters
-            which have a value of None. Notifies an error for which parameters have a none value.
+            which have a value of None. Logs an error for all parameters that have a None value.
             Returns the parameter settings which have a value.
 
         Args:

--- a/src/qilib/configuration_helper/instrument_adapter.py
+++ b/src/qilib/configuration_helper/instrument_adapter.py
@@ -109,8 +109,8 @@ class InstrumentAdapter(ABC):
         """ Return parameters from the QCoDeS snapshot which are not None.
 
             Takes the parameters of the QCoDeS instrument snapshot. Removes all parameters
-            which have a value of None. Logs an error for all parameters that have a None value.
-            Returns the parameter settings which have a value.
+            which have a value of None. Returns the parameter settings which have a value.
+            All parameters with None value will be listed in the log as an error.
 
         Args:
             snapshot: A QCoDeS instrument snapshot.
@@ -122,7 +122,7 @@ class InstrumentAdapter(ABC):
         parameters = {}
         non_value_parameters = {}
         for parameter_name, settings in snapshot['parameters'].items():
-            if 'value' in settings and settings['value'] == None:
+            if 'value' in settings and settings['value'] is None:
                 non_value_parameters[parameter_name] = settings
             else:
                 parameters[parameter_name] = settings
@@ -134,7 +134,7 @@ class InstrumentAdapter(ABC):
 
         return parameters
 
-    def __str__(self):
+    def __str__(self) -> str:
         """ Returns string representation for the InstrumentAdapter.
 
         Returns:

--- a/src/qilib/configuration_helper/instrument_adapter.py
+++ b/src/qilib/configuration_helper/instrument_adapter.py
@@ -19,7 +19,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 """
 import logging
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Dict, Any
 
 from qcodes import Instrument
 
@@ -105,7 +105,7 @@ class InstrumentAdapter(ABC):
         """
         visitor.visit(self)
 
-    def __notify_and_remove_none_values(self, snapshot):
+    def __notify_and_remove_none_values(self, snapshot: Dict[str, Any]) -> Dict[str, Any]:
         """ Gets all setted parameters from the QCoDeS snapshot.
 
             Takes the parameters of the QCoDeS instrument snapshot. Removes all parameters

--- a/src/qilib/utils/python_json_structure.py
+++ b/src/qilib/utils/python_json_structure.py
@@ -26,8 +26,9 @@ from qilib.utils.type_aliases import PJSValues
 
 class PythonJsonStructure(dict):  # type: ignore
     __serializable_key_types = (str, int)
-    __serializable_value_types = (bool, int, float, complex, str, bytes)
+    __serializable_python_types = (bool, int, float, complex, str, bytes)
     __serializable_numpy_types = (np.float32, np.float64, np.int32, np.int64, np.cfloat)
+    __serializable_value_types = (*__serializable_python_types, *__serializable_numpy_types)
 
     def __init__(self, *args: Dict[str, PJSValues], **kwargs: Any) -> None:
         """ A python container which can hold data objects and can be serialized

--- a/src/qilib/utils/python_json_structure.py
+++ b/src/qilib/utils/python_json_structure.py
@@ -25,6 +25,7 @@ from qilib.utils.type_aliases import PJSValues
 
 
 class PythonJsonStructure(dict):  # type: ignore
+    __serializable_key_types = (str, int)
     __serializable_value_types = (bool, int, float, complex, str, bytes)
     __serializable_numpy_types = (np.float32, np.float64, np.int32, np.int64, np.cfloat)
 
@@ -99,7 +100,7 @@ class PythonJsonStructure(dict):  # type: ignore
 
     @staticmethod
     def __assert_correct_key_type(key: Any) -> None:
-        if not isinstance(key, (str, int)):
+        if not isinstance(key, PythonJsonStructure.__serializable_key_types):
             raise TypeError('Invalid key! (key={})'.format(key))
 
     @staticmethod

--- a/src/tests/unittests/configuration_helper/adapters/test_ami430_instrument_adapater.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_ami430_instrument_adapater.py
@@ -9,6 +9,7 @@ from tests.test_data.dummy_instrument import DummyAMI430Instrument
 
 
 class TestAMI430InstrumentAdapter(unittest.TestCase):
+
     def test_constructor(self):
         with patch('qilib.configuration_helper.adapters.ami430_instrument_adapter.AMI430') as mock_instrument:
             address = '192.168.1.128:7180'

--- a/src/tests/unittests/configuration_helper/adapters/test_d5a_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_d5a_instrument_adapter.py
@@ -44,7 +44,6 @@ class TestD5aInstrumentAdapter(unittest.TestCase):
 
     def test_apply_config_ok(self):
         with patch('qilib.configuration_helper.adapters.spi_rack_instrument_adapter.SPI_rack') as spi_mock, \
-                patch('qilib.configuration_helper.adapters.common_instrument_adapter.logging') as logger_mock, \
                 patch('qcodes.instrument_drivers.QuTech.D5a.D5a_module') as d5a_module_mock:
             range_4volt_bi = 2
             d5a_module_mock.range_4V_bi = range_4volt_bi
@@ -65,7 +64,7 @@ class TestD5aInstrumentAdapter(unittest.TestCase):
             mocked_snapshot = {'name': 'd5a', 'parameters': self.mock_config}
             d5a_adapter.instrument.snapshot = MagicMock(return_value=mocked_snapshot)
             d5a_adapter.apply(self.mock_config)
-            logger_mock.assert_not_called()
+
             d5a_adapter.instrument.d5a.set_voltage.assert_not_called()
             d5a_adapter.instrument.d5a.change_span_update.assert_not_called()
             d5a_adapter.instrument.d5a.get_stepsize.assert_not_called()

--- a/src/tests/unittests/configuration_helper/adapters/test_d5a_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_d5a_instrument_adapter.py
@@ -108,6 +108,7 @@ class TestD5aInstrumentAdapter(unittest.TestCase):
             range_4volt_bi = 2
             d5a_module_mock.range_4V_bi = range_4volt_bi
             d5a_module_mock().span.__getitem__.return_value = range_4volt_bi
+            mock_config = copy.deepcopy(self.mock_config)
 
             address = 'spirack1_module3'
             SerialPortResolver.serial_port_identifiers = {'spirack1': 'COMnumber_test'}
@@ -119,11 +120,13 @@ class TestD5aInstrumentAdapter(unittest.TestCase):
             self.assertEqual(d5a_adapter.instrument.d5a, d5a_module_mock())
 
             identity = 'IDN'
-            self.mock_config[identity] = 'version_test'
-            mocked_snapshot = {'name': 'd5a', 'parameters': self.mock_config}
+            mock_config[identity] = 'version_test'
+            mocked_snapshot = {'name': 'd5a', 'parameters': mock_config}
             d5a_adapter.instrument.snapshot = MagicMock(return_value=mocked_snapshot)
 
             config = d5a_adapter.read()
+            mock_config.pop(identity)
             self.assertTrue(identity not in config.keys())
-            self.assertDictEqual(self.mock_config, config)
+            self.assertDictEqual(mock_config, config)
+
             d5a_adapter.instrument.close()

--- a/src/tests/unittests/configuration_helper/adapters/test_d5a_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_d5a_instrument_adapter.py
@@ -75,7 +75,8 @@ class TestD5aInstrumentAdapter(unittest.TestCase):
             d5a_adapter.instrument.close()
 
     def test_apply_config_raises_configuration_mismatch_error(self):
-        with patch('qcodes.instrument_drivers.QuTech.D5a.D5a_module') as d5a_module_mock:
+        with patch('qilib.configuration_helper.adapters.spi_rack_instrument_adapter.SPI_rack') as spi_mock, \
+            patch('qcodes.instrument_drivers.QuTech.D5a.D5a_module') as d5a_module_mock:
             range_4volt_bi = 2
             dac_value = 0.03997802734375
             d5a_module_mock.range_4V_bi = range_4volt_bi

--- a/src/tests/unittests/configuration_helper/adapters/test_f1d_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_f1d_instrument_adapter.py
@@ -115,7 +115,6 @@ class TestD5aInstrumentAdapter(unittest.TestCase):
 
     def test_apply_config(self):
         with patch('qilib.configuration_helper.adapters.spi_rack_instrument_adapter.SPI_rack') as spi_mock, \
-         patch('qilib.configuration_helper.adapters.common_instrument_adapter.logging') as logger_mock, \
          patch('qcodes.instrument_drivers.QuTech.F1d.F1d_module') as f1d_module_mock:
             address = 'spirack1_module3'
             adapter_name = 'F1dInstrumentAdapter'
@@ -128,9 +127,8 @@ class TestD5aInstrumentAdapter(unittest.TestCase):
             self.assertEqual(address, f1d_adapter.address)
             self.assertEqual(f1d_module_mock(), f1d_adapter.instrument.f1d)
             self.assertEqual(instrument_name, f1d_adapter.instrument.name)
-
             f1d_adapter.apply(self.mock_config)
-            logger_mock.assert_not_called()
+
             f1d_adapter.instrument.f1d.set_IQ_filter.assert_called_with(3)
             f1d_adapter.instrument.f1d.set_I_gain.assert_called_with('low')
             f1d_adapter.instrument.f1d.set_Q_gain.assert_called_with('high')

--- a/src/tests/unittests/configuration_helper/adapters/test_f1d_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_f1d_instrument_adapter.py
@@ -138,7 +138,7 @@ class TestD5aInstrumentAdapter(unittest.TestCase):
 
             parameter_name = 'Q_gain'
             self.mock_config[parameter_name]['value'] = None
-            error_message = f'The following parameter\(s\) of .* {parameter_name}\!'
+            error_message = f'The following parameter\(s\) of .* \[\'{parameter_name}\'\]\!'
             self.assertRaisesRegex(ValueError, error_message, f1d_adapter.apply, self.mock_config)
 
             f1d_adapter.instrument.close()

--- a/src/tests/unittests/configuration_helper/adapters/test_hdawg8_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_hdawg8_instrument_adapter.py
@@ -72,8 +72,7 @@ class TestZIHDAWG8InstrumentAdapter(unittest.TestCase):
     def test_apply(self):
         with patch.object(zhinst.utils, 'create_api_session', return_value=3 * (MagicMock(),)) as daq, \
                 patch.object(qilib.configuration_helper.adapters.hdawg8_instrument_adapter.ZIHDAWG8,
-                             'download_device_node_tree', return_value=self.node_tree) as ddnt, \
-                patch('qilib.configuration_helper.adapters.common_instrument_adapter.logging') as logger_mock:
+                             'download_device_node_tree', return_value=self.node_tree) as ddnt:
             address = 'test_dev1'
             adapter_name = 'ZIHDAWG8InstrumentAdapter'
             instrument_name = "{0}_{1}".format(adapter_name, address)
@@ -111,7 +110,6 @@ class TestZIHDAWG8InstrumentAdapter(unittest.TestCase):
             self.assertEqual(0.2, hdawg_adapter.instrument.sines_0_amplitudes_0.raw_value)
 
             hdawg_adapter.apply(config)
-            logger_mock.warning.assert_not_called()
 
             self.assertEqual(1, hdawg_adapter.instrument.system_awg_channelgrouping.raw_value)
             self.assertEqual(1, hdawg_adapter.instrument.sigouts_0_on.raw_value)
@@ -129,7 +127,6 @@ class TestZIHDAWG8InstrumentAdapter(unittest.TestCase):
 
     def test_full_node_tree(self):
         with patch.object(zhinst.utils, 'create_api_session', return_value=3 * (MagicMock(),)) as daq, \
-                patch('qilib.configuration_helper.adapters.common_instrument_adapter.logging'), \
                 open(self._node_tree_path) as node_tree, \
                 patch.object(qilib.configuration_helper.adapters.hdawg8_instrument_adapter.ZIHDAWG8,
                              'download_device_node_tree', return_value=json.load(node_tree)) as ddnt:

--- a/src/tests/unittests/configuration_helper/adapters/test_m2j_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_m2j_instrument_adapter.py
@@ -48,7 +48,6 @@ class TestM2jInstrumentAdapter(unittest.TestCase):
 
     def test_apply_config(self):
         with patch('qilib.configuration_helper.adapters.spi_rack_instrument_adapter.SPI_rack') as spi_mock, \
-         patch('qilib.configuration_helper.adapters.common_instrument_adapter.logging') as logger_mock, \
          patch('qcodes.instrument_drivers.QuTech.M2j.M2j_module') as m2j_module_mock:
             address = 'spirack1_module3'
             adapter_name = 'M2jInstrumentAdapter'

--- a/src/tests/unittests/configuration_helper/adapters/test_m2j_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_m2j_instrument_adapter.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 from unittest.mock import patch, MagicMock
 
@@ -69,10 +70,10 @@ class TestM2jInstrumentAdapter(unittest.TestCase):
             m2j_adapter.instrument.m2j.get_level.assert_not_called()
             m2j_adapter.instrument.m2j.set_gain.assert_called_once_with(ref_scale)
 
-            self.mock_config['gain']['value'] = None
-            m2j_adapter.apply(self.mock_config)
-            warning_text = 'Some parameter values of {} are None and will not be set!'.format(instrument_name)
-            logger_mock.warning.assert_called_once_with(warning_text)
+            parameter_name = 'gain'
+            self.mock_config[parameter_name]['value'] = None
+            error_message = f'The following parameter\(s\) of .* {parameter_name}\!'
+            self.assertRaisesRegex(ValueError, error_message, m2j_adapter.apply, self.mock_config)
 
             m2j_adapter.instrument.close()
 
@@ -82,6 +83,7 @@ class TestM2jInstrumentAdapter(unittest.TestCase):
             address = 'spirack1_module3'
             SerialPortResolver.serial_port_identifiers = {'spirack1': 'COMnumber_test'}
             m2j_adapter = InstrumentAdapterFactory.get_instrument_adapter('M2jInstrumentAdapter', address)
+            mock_config = copy.deepcopy(self.mock_config)
 
             spi_mock.assert_called()
             m2j_module_mock.assert_called()
@@ -89,11 +91,13 @@ class TestM2jInstrumentAdapter(unittest.TestCase):
             self.assertEqual(m2j_adapter.instrument.m2j, m2j_module_mock())
 
             identity = 'IDN'
-            self.mock_config[identity] = 'version_test'
-            mocked_snapshot = {'name': 'some_m2j', 'parameters': self.mock_config}
+            mock_config[identity] = 'version_test'
+            mocked_snapshot = {'name': 'd5a', 'parameters': mock_config}
             m2j_adapter.instrument.snapshot = MagicMock(return_value=mocked_snapshot)
 
             config = m2j_adapter.read()
+            mock_config.pop(identity)
             self.assertTrue(identity not in config.keys())
-            self.assertDictEqual(self.mock_config, config)
+            self.assertDictEqual(mock_config, config)
+
             m2j_adapter.instrument.close()

--- a/src/tests/unittests/configuration_helper/adapters/test_m2j_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_m2j_instrument_adapter.py
@@ -72,7 +72,7 @@ class TestM2jInstrumentAdapter(unittest.TestCase):
 
             parameter_name = 'gain'
             self.mock_config[parameter_name]['value'] = None
-            error_message = f'The following parameter\(s\) of .* {parameter_name}\!'
+            error_message = f'The following parameter\(s\) of .* \[\'{parameter_name}\'\]\!'
             self.assertRaisesRegex(ValueError, error_message, m2j_adapter.apply, self.mock_config)
 
             m2j_adapter.instrument.close()

--- a/src/tests/unittests/configuration_helper/adapters/test_s5i_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_s5i_instrument_adapter.py
@@ -107,7 +107,7 @@ class TestS5iInstrumentAdapter(unittest.TestCase):
 
             parameter_name = 'frequency'
             self.mock_config[parameter_name]['value'] = None
-            error_message = f'The following parameter\(s\) of .* {parameter_name}\!'
+            error_message = f'The following parameter\(s\) of .* \[\'{parameter_name}\'\]\!'
             self.assertRaisesRegex(ValueError, error_message, s5i_adapter.apply, self.mock_config)
 
             s5i_adapter.instrument.close()

--- a/src/tests/unittests/configuration_helper/adapters/test_s5i_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_s5i_instrument_adapter.py
@@ -85,7 +85,6 @@ class TestS5iInstrumentAdapter(unittest.TestCase):
 
     def test_apply_config(self):
         with patch('qilib.configuration_helper.adapters.spi_rack_instrument_adapter.SPI_rack') as spi_mock, \
-                patch('qilib.configuration_helper.adapters.common_instrument_adapter.logging') as logger_mock, \
                 patch('qcodes.instrument_drivers.QuTech.S5i.S5i_module') as s5i_module_mock:
             address = 'spirack1_module3'
             adapter_name = 'S5iInstrumentAdapter'

--- a/src/tests/unittests/configuration_helper/adapters/test_uhfli_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_uhfli_instrument_adapter.py
@@ -39,8 +39,7 @@ class TestZIUHFLIInstrumentAdapter(unittest.TestCase):
         adapter.instrument.close()
 
     def test_int64_convert_to_int(self):
-        with patch.object(zhinst.utils, 'create_api_session', return_value=3 * (MagicMock(),)), \
-             patch('qilib.configuration_helper.adapters.common_instrument_adapter.logging') as logger_mock:
+        with patch.object(zhinst.utils, 'create_api_session', return_value=3 * (MagicMock(),)):
             adapter = InstrumentAdapterFactory.get_instrument_adapter('ZIUHFLIInstrumentAdapter', 'dev4142')
 
             adapter.instrument.scope_trig_level(np.int64(1))

--- a/src/tests/unittests/configuration_helper/adapters/test_uhfli_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_uhfli_instrument_adapter.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import zhinst
@@ -8,15 +8,19 @@ from qilib.configuration_helper import InstrumentAdapterFactory
 
 
 class TestZIUHFLIInstrumentAdapter(unittest.TestCase):
+
     def test_read_apply(self):
-        with patch.object(zhinst.utils, 'create_api_session', return_value=3 * (MagicMock(),)), \
-             patch('qilib.configuration_helper.adapters.common_instrument_adapter.logging') as logger_mock:
+        with patch.object(zhinst.utils, 'create_api_session', return_value=3 * (MagicMock(),)):
             adapter = InstrumentAdapterFactory.get_instrument_adapter('ZIUHFLIInstrumentAdapter', 'dev4242')
             adapter.instrument.scope_trig_level(0.2)
             trigger_level = adapter.instrument.scope_trig_level.raw_value
             self.assertEqual(0.2, trigger_level)
-            config = adapter.read()
 
+            with self.assertLogs(level='ERROR') as log_grabber:
+                config = adapter.read()
+
+            expected_regex = "Parameter values of ZIUHFLIInstrumentAdapter_dev4242 are .*"
+            self.assertRegex(log_grabber.records[0].message, expected_regex)
             self.assertTrue(all(['val_mapping' not in config[key] for key in config.keys()]))
 
             adapter.instrument.scope_trig_level(0.7)
@@ -27,8 +31,10 @@ class TestZIUHFLIInstrumentAdapter(unittest.TestCase):
             trigger_level = adapter.instrument.scope_trig_level.raw_value
             self.assertEqual(0.2, trigger_level)
 
-            logger_mock.warning.assert_called_with('Some parameter values of ZIUHFLIInstrumentAdapter_dev4242 are'
-                                                   ' None and will not be set!')
+            parameter_name = 'scope_trig_level'
+            config[parameter_name]['value'] = None
+            error_message = f'The following parameter\(s\) of .* {parameter_name}\!'
+            self.assertRaisesRegex(ValueError, error_message, adapter.apply, config)
 
         adapter.instrument.close()
 
@@ -42,12 +48,15 @@ class TestZIUHFLIInstrumentAdapter(unittest.TestCase):
             adapter.instrument.scope_trig_hystabsolute(np.int64(2))
             self.assertIsInstance(adapter.instrument.scope_trig_hystabsolute.raw_value, np.int64)
 
-            config = adapter.read()
+            with self.assertLogs(level='ERROR') as log_grabber:
+                config = adapter.read()
+
+            expected_regex = "Parameter values of ZIUHFLIInstrumentAdapter_dev4142 are .*"
+            self.assertRegex(log_grabber.records[0].message, expected_regex)
             adapter.apply(config)
 
             for parameter in adapter.instrument.parameters.values():
                 if hasattr(parameter, 'raw_value'):
                     self.assertNotIsInstance(parameter.raw_value, np.int64)
-            logger_mock.warning.assert_called_with('Some parameter values of ZIUHFLIInstrumentAdapter_dev4142 are'
-                                                   ' None and will not be set!')
-            adapter.instrument.close()
+
+        adapter.instrument.close()

--- a/src/tests/unittests/configuration_helper/adapters/test_uhfli_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_uhfli_instrument_adapter.py
@@ -33,7 +33,7 @@ class TestZIUHFLIInstrumentAdapter(unittest.TestCase):
 
             parameter_name = 'scope_trig_level'
             config[parameter_name]['value'] = None
-            error_message = f'The following parameter\(s\) of .* {parameter_name}\!'
+            error_message = f'The following parameter\(s\) of .* \[\'{parameter_name}\'\]\!'
             self.assertRaisesRegex(ValueError, error_message, adapter.apply, config)
 
         adapter.instrument.close()
@@ -60,3 +60,11 @@ class TestZIUHFLIInstrumentAdapter(unittest.TestCase):
                     self.assertNotIsInstance(parameter.raw_value, np.int64)
 
         adapter.instrument.close()
+
+    def test_filtered_parameters(self):
+        with patch.object(zhinst.utils, 'create_api_session', return_value=3 * (MagicMock(),)):
+            adapter = InstrumentAdapterFactory.get_instrument_adapter('ZIUHFLIInstrumentAdapter', 'dev4242')
+
+            adapter.instrument.value_mapping = 1
+            with self.assertLogs(level='ERROR') as log_grabber:
+                config = adapter.read()

--- a/src/tests/unittests/configuration_helper/adapters/test_uhfli_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_uhfli_instrument_adapter.py
@@ -65,6 +65,11 @@ class TestZIUHFLIInstrumentAdapter(unittest.TestCase):
         with patch.object(zhinst.utils, 'create_api_session', return_value=3 * (MagicMock(),)):
             adapter = InstrumentAdapterFactory.get_instrument_adapter('ZIUHFLIInstrumentAdapter', 'dev4242')
 
+            adapter.instrument.demod1_oscillator(1)
+
             adapter.instrument.value_mapping = 1
             with self.assertLogs(level='ERROR') as log_grabber:
                 config = adapter.read()
+
+            self.assertTrue(all(['val_mapping' not in config[key] for key in config.keys()]))
+            self.assertTrue('IDN' not in config.keys())

--- a/src/tests/unittests/configuration_helper/test_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/test_instrument_adapter.py
@@ -36,4 +36,3 @@ class TestInstrumentAdapter(unittest.TestCase):
         adapter_str = str(adapter)
         self.assertEqual('InstrumentAdapter: DummyInstrumentAdapter_some_address', adapter_str)
         adapter.close_instrument()
-

--- a/src/tests/unittests/utils/test_python_json_structure.py
+++ b/src/tests/unittests/utils/test_python_json_structure.py
@@ -63,10 +63,15 @@ class TestPythonJsonStructure(unittest.TestCase):
             'list': [1, 2, 3],
             'str': 'some_string',
             'bytes': b'1010101',
+            'json_object': PythonJsonStructure(),
+            'np.float32': np.float32(3.1415),
+            'np.float64': np.float64(-3.1415),
+            'np.int32': np.int32(4),
+            'np.in64': np.int64(-4),
+            'np.cfloat': np.random.rand(2, 4, 5, 3).astype(np.cfloat),
             'tuple': (1, 2, 3),
             'dict': {'a': 1, 'b': 2, 'c': 3},
-            'ndarray': np.array([[1, 2], [3, 4]]),
-            'json_object': PythonJsonStructure()
+            'ndarray': np.array([[1, 2], [3, 4]])
         }
 
         json_object = PythonJsonStructure()
@@ -183,12 +188,18 @@ class TestPythonJsonStructure(unittest.TestCase):
             'float': 3.141592,
             'str': 'some_string',
             'bytes': b'1010101',
+            'np.float32': np.float32(3.1415),
+            'np.float64': np.float64(-3.1415),
+            'np.int32': np.int32(4),
+            'np.in64': np.int64(-4),
+            'np.cfloat': np.random.rand(2, 4, 5, 3).astype(np.cfloat),
         }
         for key, expected in settable_objects.items():
             json_object = PythonJsonStructure({key: expected})
             serialized_object = serialize(json_object)
             unserialized_object = unserialize(serialized_object)
-            self.assertEqual(json_object, unserialized_object)
+            np.testing.assert_equal(json_object, unserialized_object)
+
 
     def test_serialization_container_types(self):
         """ Creates a PythonJsonStucture with all the data-types. Serializes the


### PR DESCRIPTION
The following changes have been implemented for reading and applying the configuration of an instrument adapter:

- Raise a logging error for each parameter with value none when you create/read a configuration.
- Raise an exception when a configuration is applied with a parameter with value None.