### PR TITLE
[DEM-1189] Improve how external adapters are added to factory

### DIFF
--- a/src/qilib/configuration_helper/__init__.py
+++ b/src/qilib/configuration_helper/__init__.py
@@ -5,4 +5,6 @@ from qilib.configuration_helper.instrument_configuration_set import InstrumentCo
 from qilib.configuration_helper.instrument_configuration_visitor import InstrumentConfigurationVisitor
 from qilib.configuration_helper.serial_port_resolver import SerialPortResolver
 from qilib.configuration_helper.configuration_helper import ConfigurationHelper
-import qilib.configuration_helper.adapters
+from qilib.configuration_helper import adapters
+
+InstrumentAdapterFactory.add_instrument_adapter_package(adapters)

--- a/src/qilib/configuration_helper/instrument_adapter_factory.py
+++ b/src/qilib/configuration_helper/instrument_adapter_factory.py
@@ -32,7 +32,13 @@ class InstrumentAdapterFactory:
     instrument as well as a dictionary that provides key-value pairs of address specifications.
     """
 
+    #: A container that holds all instantiated instrument adapters created by the factory.
+    #: When an adapter is requested via the get_instrument_adapter method, this dictionary is
+    #: checked first for an existing adapter with same name and address.
     adapter_instances: Dict[Tuple[str, str], InstrumentAdapter] = {}
+
+    #: A dictionary containing all available adapters. External adapters can be added via add_instrument_adapter_package
+    #: or add_instrument_adapter_class.
     _instrument_adapters: Dict[str, Type[InstrumentAdapter]] = {}
 
     @classmethod

--- a/src/qilib/configuration_helper/instrument_adapter_factory.py
+++ b/src/qilib/configuration_helper/instrument_adapter_factory.py
@@ -17,11 +17,11 @@ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEM
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+import inspect
 from types import ModuleType
-from typing import Dict, Tuple, cast, Optional
+from typing import Dict, Tuple, Optional, Type
 
-import qilib
-from qilib.configuration_helper import InstrumentAdapter
+from qilib.configuration_helper.instrument_adapter import InstrumentAdapter
 
 
 class InstrumentAdapterFactory:
@@ -32,18 +32,33 @@ class InstrumentAdapterFactory:
     instrument as well as a dictionary that provides key-value pairs of address specifications.
     """
 
-    instrument_adapters: Dict[Tuple[str, str], InstrumentAdapter] = {}
-    _external_adapters: Dict[str, ModuleType] = {}
+    adapter_instances: Dict[Tuple[str, str], InstrumentAdapter] = {}
+    _instrument_adapters: Dict[str, Type[InstrumentAdapter]] = {}
 
-    @staticmethod
-    def add_instrument_adapters(package: ModuleType):
+    @classmethod
+    def add_instrument_adapter_package(cls, package: ModuleType) -> None:
         """ Adds InstrumentAdapters (from an external package)
 
         Args:
             package: The package that contains InstrumentAdapters
+
         """
 
-        InstrumentAdapterFactory._external_adapters.update(vars(package))
+        for adapter in inspect.getmembers(package, lambda m: inspect.isclass(m) and issubclass(m, InstrumentAdapter)):
+            cls.add_instrument_adapter_class(adapter[1])
+
+    @classmethod
+    def add_instrument_adapter_class(cls, adapter: Type[InstrumentAdapter]) -> None:
+        """
+        Args:
+            adapter: Adapter class to be added to the factory.
+        Raises:
+            TypeError: If the adapter is not subclass of InstrumentAdapter.
+
+        """
+        if not issubclass(adapter, InstrumentAdapter):
+            raise TypeError(f'{adapter.__name__} is not a subclass of InstrumentAdapter')
+        cls._instrument_adapters[adapter.__name__] = adapter
 
     @classmethod
     def get_instrument_adapter(cls, instrument_adapter_class_name: str, address: str,
@@ -63,20 +78,24 @@ class InstrumentAdapterFactory:
 
         """
         instrument_adapter_key = instrument_adapter_class_name, str(address)
-        if instrument_adapter_key in cls.instrument_adapters:
-            adapter = cls.instrument_adapters[instrument_adapter_key]
-            if instrument_name is not None and instrument_name != adapter.instrument.name:
-                raise ValueError(f'An adapter exist with different instrument name'
-                                 f' \'{adapter.instrument.name}\' != \'{instrument_name}\'')
-            return adapter
-
-        adapter = vars(qilib.configuration_helper.adapters).get(instrument_adapter_class_name,
-                                                                InstrumentAdapterFactory._external_adapters.get(
-                                                                    instrument_adapter_class_name))
-        if adapter is None:
-            raise ValueError(f"No such InstrumentAdapter {instrument_adapter_class_name}")
+        if instrument_adapter_key in cls.adapter_instances:
+            return cls._get_adapter_instance(instrument_adapter_key, instrument_name)
+        elif instrument_adapter_class_name in cls._instrument_adapters:
+            return cls._get_new_adapter_instance(address, instrument_adapter_class_name, instrument_name)
         else:
-            args = (address, instrument_name) if instrument_name is not None else (address,)
-            adapter = cast(InstrumentAdapter, adapter(*args))
-            cls.instrument_adapters[instrument_adapter_key] = adapter
-            return adapter
+            raise ValueError(f"No such InstrumentAdapter {instrument_adapter_class_name}")
+
+    @classmethod
+    def _get_new_adapter_instance(cls, address, class_name, instrument_name):
+        args = (address, instrument_name) if instrument_name is not None else (address,)
+        adapter = cls._instrument_adapters[class_name](*args)
+        cls.adapter_instances[(class_name, str(address))] = adapter
+        return adapter
+
+    @classmethod
+    def _get_adapter_instance(cls, instrument_adapter_key, instrument_name):
+        adapter = cls.adapter_instances[instrument_adapter_key]
+        if instrument_name is not None and instrument_name != adapter.instrument.name:
+            raise ValueError(f'An adapter exist with different instrument name'
+                             f' \'{adapter.instrument.name}\' != \'{instrument_name}\'')
+        return adapter

--- a/src/tests/test_data/dummy_instrument.py
+++ b/src/tests/test_data/dummy_instrument.py
@@ -23,10 +23,14 @@ class DummyInstrument(Instrument):
                            set_cmd=None,
                            label=name)
 
+    def __str__(self):
+        return self.__class__.__name__
+
     def get_idn(self):
         idn = {'vendor': 'QuTech', 'model': self.name,
                'serial': 42, 'firmware': '20-05-2019-RC'}
         return idn
+
 
 class DummyAMI430Instrument(Instrument):
 

--- a/src/tests/unittests/configuration_helper/adapters/test_d5a_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_d5a_instrument_adapter.py
@@ -11,7 +11,7 @@ from qilib.configuration_helper.adapters.d5a_instrument_adapter import SpanValue
 class TestD5aInstrumentAdapter(unittest.TestCase):
 
     def setUp(self):
-        InstrumentAdapterFactory.instrument_adapters.clear()
+        InstrumentAdapterFactory.adapter_instances.clear()
 
         self.mock_config = {
             'name': 'd5a',

--- a/src/tests/unittests/configuration_helper/adapters/test_f1d_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_f1d_instrument_adapter.py
@@ -8,7 +8,7 @@ from qilib.configuration_helper import InstrumentAdapterFactory, SerialPortResol
 class TestD5aInstrumentAdapter(unittest.TestCase):
 
     def setUp(self):
-        InstrumentAdapterFactory.instrument_adapters.clear()
+        InstrumentAdapterFactory.adapter_instances.clear()
 
         self.mock_config = {
             'name': 'F1dInstrumentAdapter_spirack1_module3',

--- a/src/tests/unittests/configuration_helper/adapters/test_m2j_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_m2j_instrument_adapter.py
@@ -11,7 +11,7 @@ from qilib.configuration_helper import (InstrumentAdapterFactory,
 class TestM2jInstrumentAdapter(unittest.TestCase):
 
     def setUp(self):
-        InstrumentAdapterFactory.instrument_adapters.clear()
+        InstrumentAdapterFactory.adapter_instances.clear()
 
         self.mock_config = {
             'name': 'M2jInstrumentAdapter_spirack1_module3',

--- a/src/tests/unittests/configuration_helper/adapters/test_s5i_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_s5i_instrument_adapter.py
@@ -8,7 +8,7 @@ from qilib.configuration_helper import InstrumentAdapterFactory, SerialPortResol
 class TestS5iInstrumentAdapter(unittest.TestCase):
 
     def setUp(self):
-        InstrumentAdapterFactory.instrument_adapters.clear()
+        InstrumentAdapterFactory.adapter_instances.clear()
 
         self.mock_config = {
             'name': 'S5iInstrumentAdapter_spirack1_module3',

--- a/src/tests/unittests/configuration_helper/adapters/test_spi_module_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_spi_module_instrument_adapter.py
@@ -8,7 +8,7 @@ from qilib.configuration_helper.adapters import SpiModuleInstrumentAdapter
 class TestSpiModuleInstrumentAdapter(TestCase):
 
     def setUp(self):
-        InstrumentAdapterFactory.instrument_adapters = {}
+        InstrumentAdapterFactory.adapter_instances = {}
 
     def test_create_has_invalid_address(self):
         invalid_address = 'ItIsInvalid'

--- a/src/tests/unittests/configuration_helper/adapters/test_spi_rack_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_spi_rack_instrument_adapter.py
@@ -8,7 +8,7 @@ from qilib.utils import PythonJsonStructure
 class TestSpiRackInstrumentAdapter(TestCase):
 
     def setUp(self):
-        InstrumentAdapterFactory.instrument_adapters = {}
+        InstrumentAdapterFactory.adapter_instances = {}
         self.serial_port_settings = PythonJsonStructure(MagicMock(spec=dict()))
         self.mock_config = PythonJsonStructure({
             'version': 1.23,

--- a/src/tests/unittests/configuration_helper/test_instrument_adapter_factory.py
+++ b/src/tests/unittests/configuration_helper/test_instrument_adapter_factory.py
@@ -32,7 +32,7 @@ class TestInstrumentAdapterFactory(unittest.TestCase):
         with self.assertRaises(ValueError):
             InstrumentAdapterFactory.get_instrument_adapter('SomeAdapter', 'dev42')
 
-    def test_adda_wrong_class_raises_type_error(self):
+    def test_add_wrong_class_raises_type_error(self):
         error = (TypeError, 'DummyInstrument is not a subclass of InstrumentAdapter')
         self.assertRaisesRegex(*error, InstrumentAdapterFactory.add_instrument_adapter_class, DummyInstrument)
 

--- a/src/tests/unittests/configuration_helper/test_instrument_adapter_factory.py
+++ b/src/tests/unittests/configuration_helper/test_instrument_adapter_factory.py
@@ -3,13 +3,14 @@ import unittest
 
 import tests
 from qilib.configuration_helper import InstrumentAdapterFactory
+from tests.test_data.dummy_instrument import DummyInstrument
 from tests.test_data.dummy_instrument_adapter import DummyInstrumentAdapter
 
 
 class TestInstrumentAdapterFactory(unittest.TestCase):
 
     def setUp(self):
-        InstrumentAdapterFactory.add_instrument_adapters(tests.test_data.dummy_instrument_adapter)
+        InstrumentAdapterFactory.add_instrument_adapter_package(tests.test_data.dummy_instrument_adapter)
 
     def test_factory_creates_single_instance(self):
         dummy_adapter1 = InstrumentAdapterFactory.get_instrument_adapter('DummyInstrumentAdapter', 'dev1')
@@ -31,20 +32,17 @@ class TestInstrumentAdapterFactory(unittest.TestCase):
         with self.assertRaises(ValueError):
             InstrumentAdapterFactory.get_instrument_adapter('SomeAdapter', 'dev42')
 
-    def test_external_adapters_add_not_called(self):
-        from importlib import reload
-        from qilib.configuration_helper import instrument_adapter_factory
+    def test_adda_wrong_class_raises_type_error(self):
+        error = (TypeError, 'DummyInstrument is not a subclass of InstrumentAdapter')
+        self.assertRaisesRegex(*error, InstrumentAdapterFactory.add_instrument_adapter_class, DummyInstrument)
 
-        reload(instrument_adapter_factory)
-        self.assertRaises(ValueError, InstrumentAdapterFactory.get_instrument_adapter, 'DummyInstrumentAdapter', '')
-
-    def test_external_adapters_add_is_called(self):
-        InstrumentAdapterFactory.add_instrument_adapters(sys.modules[__name__])
+    def test_add_instrument_adapter_package(self):
+        InstrumentAdapterFactory.add_instrument_adapter_package(sys.modules[__name__])
 
         dummy_adapter = InstrumentAdapterFactory.get_instrument_adapter('DummyInstrumentAdapter', '')
         self.assertIsInstance(dummy_adapter, DummyInstrumentAdapter)
 
-        InstrumentAdapterFactory.instrument_adapters.pop(('DummyInstrumentAdapter', ''))
+        InstrumentAdapterFactory.adapter_instances.pop(('DummyInstrumentAdapter', ''))
         dummy_adapter.close_instrument()
 
     def test_different_instrument_name_raises_error(self):

--- a/src/tests/unittests/configuration_helper/test_serialport_resolver.py
+++ b/src/tests/unittests/configuration_helper/test_serialport_resolver.py
@@ -7,7 +7,7 @@ from qilib.configuration_helper import adapters, SerialPortResolver, InstrumentA
 class TestSerialPortResolver(TestCase):
 
     def setUp(self):
-        InstrumentAdapterFactory.instrument_adapters.clear()
+        InstrumentAdapterFactory.adapter_instances.clear()
 
     def test_get_serialport_adapter_invalid_key(self):
         adapters.InstrumentAdapter = MagicMock()


### PR DESCRIPTION
* Added a method that allows single instrument adapters to be added to instrument adapter facotry
* Raise Type error if adapter to be added is not a subclass of InstrumentAdapter
* Change the name of method that allows import of whole adapter packages
* Only add classes that are subclasses of InstrumentAdapter
 