### PR TITLE
[DEM-1109] Update baseline configuration

### DIFF
--- a/src/qilib/configuration_helper/adapters/d5a_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/d5a_instrument_adapter.py
@@ -19,7 +19,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 """
 from typing import Any, Optional
 
-from qcodes.instrument_drivers.QuTech.D5a import D5a
+from qcodes_contrib_drivers.drivers.QuTech.D5a import D5a
 
 from qilib.configuration_helper.adapters.read_only_configuration_instrument_adapter import ReadOnlyConfigurationInstrumentAdapter
 from qilib.configuration_helper.adapters.spi_module_instrument_adapter import SpiModuleInstrumentAdapter

--- a/src/qilib/configuration_helper/adapters/f1d_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/f1d_instrument_adapter.py
@@ -19,7 +19,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 """
 from typing import Optional
 
-from qcodes.instrument_drivers.QuTech.F1d import F1d
+from qcodes_contrib_drivers.drivers.QuTech.F1d import F1d
 
 from qilib.configuration_helper.adapters.spi_module_instrument_adapter import SpiModuleInstrumentAdapter
 

--- a/src/qilib/configuration_helper/adapters/hdawg8_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/hdawg8_instrument_adapter.py
@@ -19,7 +19,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 """
 from typing import Optional
 
-from qcodes.instrument_drivers.ZI.ZIHDAWG8 import ZIHDAWG8
+from qcodes_contrib_drivers.drivers.ZurichInstruments.ZIHDAWG8 import ZIHDAWG8
 
 from qilib.configuration_helper.adapters.common_instrument_adapter import CommonInstrumentAdapter
 from qilib.utils import PythonJsonStructure
@@ -34,7 +34,10 @@ class ZIHDAWG8InstrumentAdapter(CommonInstrumentAdapter):
         return PythonJsonStructure(super().read(update))
 
     def _filter_parameters(self, parameters: PythonJsonStructure) -> PythonJsonStructure:
-        filtered = {parameter: value for (parameter, value) in parameters.items() if 'system_nics_' not in parameter}
+        filter_items = ['_elf_data', '_waveform_descriptors', '_sequencer_program', '_sequencer_assembly', '_elf_name',
+                        '_dio_data', '_waveform_waves_', 'system_nics_', 'triggers_streams_', 'features_code']
+        filtered = {parameter: value for (parameter, value) in parameters.items()
+                    if all(filter not in parameter for filter in filter_items)}
         return PythonJsonStructure(filtered)
 
     def start(self, awg_number: int) -> None:

--- a/src/qilib/configuration_helper/adapters/keysight_e8267d_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/keysight_e8267d_instrument_adapter.py
@@ -19,7 +19,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 """
 from typing import Optional
 
-from qcodes.instrument_drivers.Keysight.Keysight_E8267D import Keysight_E8267D
+from qcodes_contrib_drivers.drivers.Keysight.Keysight_E8267D import Keysight_E8267D
 
 from qilib.configuration_helper.adapters.common_instrument_adapter import CommonInstrumentAdapter
 from qilib.utils import PythonJsonStructure

--- a/src/qilib/configuration_helper/adapters/m2j_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/m2j_instrument_adapter.py
@@ -19,7 +19,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 """
 from typing import Optional
 
-from qcodes.instrument_drivers.QuTech.M2j import M2j
+from qcodes_contrib_drivers.drivers.QuTech.M2j import M2j
 
 from qilib.configuration_helper.adapters.spi_module_instrument_adapter import SpiModuleInstrumentAdapter
 

--- a/src/qilib/configuration_helper/adapters/m4i_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/m4i_instrument_adapter.py
@@ -36,5 +36,6 @@ class M4iInstrumentAdapter(CommonInstrumentAdapter):
         if parameters['box_averages']['value'] == 1:
             parameters.pop('box_averages')
 
+        parameters.pop('card_available_length')
         parameters.pop('IDN')
         return parameters

--- a/src/qilib/configuration_helper/adapters/s5i_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/s5i_instrument_adapter.py
@@ -19,7 +19,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 """
 from typing import Optional
 
-from qcodes.instrument_drivers.QuTech.S5i import S5i
+from qcodes_contrib_drivers.drivers.QuTech.S5i import S5i
 
 from qilib.configuration_helper.adapters.spi_module_instrument_adapter import SpiModuleInstrumentAdapter
 

--- a/src/tests/unittests/configuration_helper/adapters/test_d5a_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_d5a_instrument_adapter.py
@@ -44,7 +44,7 @@ class TestD5aInstrumentAdapter(unittest.TestCase):
 
     def test_apply_config_ok(self):
         with patch('qilib.configuration_helper.adapters.spi_rack_instrument_adapter.SPI_rack') as spi_mock, \
-                patch('qcodes.instrument_drivers.QuTech.D5a.D5a_module') as d5a_module_mock:
+                patch('qcodes_contrib_drivers.drivers.QuTech.D5a.D5a_module') as d5a_module_mock:
             range_4volt_bi = 2
             d5a_module_mock.range_4V_bi = range_4volt_bi
             d5a_module_mock().span.__getitem__.return_value = range_4volt_bi
@@ -75,7 +75,7 @@ class TestD5aInstrumentAdapter(unittest.TestCase):
 
     def test_apply_config_raises_configuration_mismatch_error(self):
         with patch('qilib.configuration_helper.adapters.spi_rack_instrument_adapter.SPI_rack'), \
-            patch('qcodes.instrument_drivers.QuTech.D5a.D5a_module') as d5a_module_mock:
+            patch('qcodes_contrib_drivers.drivers.QuTech.D5a.D5a_module') as d5a_module_mock:
             range_4volt_bi = 2
             dac_value = 0.03997802734375
             d5a_module_mock.range_4V_bi = range_4volt_bi
@@ -104,7 +104,7 @@ class TestD5aInstrumentAdapter(unittest.TestCase):
 
     def test_read_config(self):
         with patch('qilib.configuration_helper.adapters.spi_rack_instrument_adapter.SPI_rack') as spi_mock, \
-                patch('qcodes.instrument_drivers.QuTech.D5a.D5a_module') as d5a_module_mock:
+                patch('qcodes_contrib_drivers.drivers.QuTech.D5a.D5a_module') as d5a_module_mock:
             range_4volt_bi = 2
             d5a_module_mock.range_4V_bi = range_4volt_bi
             d5a_module_mock().span.__getitem__.return_value = range_4volt_bi
@@ -121,7 +121,7 @@ class TestD5aInstrumentAdapter(unittest.TestCase):
 
             identity = 'IDN'
             mock_config[identity] = 'version_test'
-            mocked_snapshot = {'name': 'd5a', 'parameters': mock_config}
+            mocked_snapshot = {'name': 'd5a', 'parameters': mock_config.copy()}
             d5a_adapter.instrument.snapshot = MagicMock(return_value=mocked_snapshot)
 
             config = d5a_adapter.read()

--- a/src/tests/unittests/configuration_helper/adapters/test_f1d_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_f1d_instrument_adapter.py
@@ -115,7 +115,7 @@ class TestD5aInstrumentAdapter(unittest.TestCase):
 
     def test_apply_config(self):
         with patch('qilib.configuration_helper.adapters.spi_rack_instrument_adapter.SPI_rack') as spi_mock, \
-         patch('qcodes.instrument_drivers.QuTech.F1d.F1d_module') as f1d_module_mock:
+         patch('qcodes_contrib_drivers.drivers.QuTech.F1d.F1d_module') as f1d_module_mock:
             address = 'spirack1_module3'
             adapter_name = 'F1dInstrumentAdapter'
             instrument_name = '{0}_{1}'.format(adapter_name, address)
@@ -143,7 +143,7 @@ class TestD5aInstrumentAdapter(unittest.TestCase):
 
     def test_read_config(self):
         with patch('qilib.configuration_helper.adapters.spi_rack_instrument_adapter.SPI_rack') as spi_mock, \
-         patch('qcodes.instrument_drivers.QuTech.F1d.F1d_module') as f1d_module_mock:
+         patch('qcodes_contrib_drivers.drivers.QuTech.F1d.F1d_module') as f1d_module_mock:
             address = 'spirack1_module3'
             SerialPortResolver.serial_port_identifiers = {'spirack1': 'COMnumber_test'}
             f1d_adapter = InstrumentAdapterFactory.get_instrument_adapter('F1dInstrumentAdapter', address)
@@ -156,7 +156,7 @@ class TestD5aInstrumentAdapter(unittest.TestCase):
 
             identity = 'IDN'
             mock_config[identity] = 'version_test'
-            mocked_snapshot = {'name': 'd5a', 'parameters': mock_config}
+            mocked_snapshot = {'name': 'd5a', 'parameters': mock_config.copy()}
             f1d_adapter.instrument.snapshot = MagicMock(return_value=mocked_snapshot)
 
             config = f1d_adapter.read()

--- a/src/tests/unittests/configuration_helper/adapters/test_hdawg8_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_hdawg8_instrument_adapter.py
@@ -138,20 +138,13 @@ class TestZIHDAWG8InstrumentAdapter(unittest.TestCase):
             daq.return_value[1].getDouble.return_value = 0.5
             daq.return_value[1].getString.return_value = "Test String"
             daq.return_value[1].getAsEvent.return_value = [0.1, 0.2, 0.3, 0.4]
-            expected_regex = f"Parameter values of {hdawg_adapter.name} are .*"
-            with self.assertLogs(level='ERROR') as log_grabber:
-                config_original = hdawg_adapter.read()
-
-            self.assertRegex(log_grabber.records[0].message, expected_regex)
+            config_original = hdawg_adapter.read()
 
             daq.return_value[1].getInt.return_value = 0
             daq.return_value[1].getDouble.return_value = 0.7
             daq.return_value[1].getString.return_value = "New String"
             daq.return_value[1].getAsEvent.return_value = [0.5, 0.6, 0.7, 0.8]
-            with self.assertLogs(level='ERROR') as log_grabber:
-                config_new = hdawg_adapter.read()
-
-            self.assertRegex(log_grabber.records[0].message, expected_regex)
+            config_new = hdawg_adapter.read()
 
             # Apply original config and assert parameters have been updated
             hdawg_adapter.apply(config_original)
@@ -230,11 +223,8 @@ class TestZIHDAWG8InstrumentAdapter(unittest.TestCase):
             daq.return_value[1].getString.return_value = "Test String"
             daq.return_value[1].getAsEvent.return_value = [0.1, 0.2, 0.3, 0.4]
 
-            expected_regex = f"Parameter values of {hdawg_adapter.name} are .*"
-            with self.assertLogs(level='ERROR') as log_grabber:
-                config = hdawg_adapter.read()
+            config = hdawg_adapter.read()
 
-        self.assertRegex(log_grabber.records[0].message, expected_regex)
         self.assertNotIn('system_nics_0_defaultip4', config)
         self.assertNotIn('system_nics_0_defaultmask', config)
         self.assertNotIn('system_nics_0_defaultgateway', config)

--- a/src/tests/unittests/configuration_helper/adapters/test_m2j_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_m2j_instrument_adapter.py
@@ -2,7 +2,7 @@ import copy
 import unittest
 from unittest.mock import patch, MagicMock
 
-from qcodes.instrument_drivers.QuTech.M2j import M2j
+from qcodes_contrib_drivers.drivers.QuTech.M2j import M2j
 
 from qilib.configuration_helper import (InstrumentAdapterFactory,
                                      SerialPortResolver)
@@ -48,7 +48,7 @@ class TestM2jInstrumentAdapter(unittest.TestCase):
 
     def test_apply_config(self):
         with patch('qilib.configuration_helper.adapters.spi_rack_instrument_adapter.SPI_rack') as spi_mock, \
-         patch('qcodes.instrument_drivers.QuTech.M2j.M2j_module') as m2j_module_mock:
+         patch('qcodes_contrib_drivers.drivers.QuTech.M2j.M2j_module') as m2j_module_mock:
             address = 'spirack1_module3'
             adapter_name = 'M2jInstrumentAdapter'
             instrument_name = '{0}_{1}'.format(adapter_name, address)
@@ -78,7 +78,7 @@ class TestM2jInstrumentAdapter(unittest.TestCase):
 
     def test_read_config(self):
         with patch('qilib.configuration_helper.adapters.spi_rack_instrument_adapter.SPI_rack') as spi_mock, \
-         patch('qcodes.instrument_drivers.QuTech.M2j.M2j_module') as m2j_module_mock:
+         patch('qcodes_contrib_drivers.drivers.QuTech.M2j.M2j_module') as m2j_module_mock:
             address = 'spirack1_module3'
             SerialPortResolver.serial_port_identifiers = {'spirack1': 'COMnumber_test'}
             m2j_adapter = InstrumentAdapterFactory.get_instrument_adapter('M2jInstrumentAdapter', address)
@@ -91,7 +91,7 @@ class TestM2jInstrumentAdapter(unittest.TestCase):
 
             identity = 'IDN'
             mock_config[identity] = 'version_test'
-            mocked_snapshot = {'name': 'd5a', 'parameters': mock_config}
+            mocked_snapshot = {'name': 'd5a', 'parameters': mock_config.copy()}
             m2j_adapter.instrument.snapshot = MagicMock(return_value=mocked_snapshot)
 
             config = m2j_adapter.read()

--- a/src/tests/unittests/configuration_helper/adapters/test_m4i_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_m4i_instrument_adapter.py
@@ -54,13 +54,14 @@ class TestM4iInstrumentAdapter(TestCase):
     def test_read_config(self):
         with patch('qcodes_contrib_drivers.drivers.Spectrum.M4i.M4i') as m4i_mock:
             adapter = InstrumentAdapterFactory.get_instrument_adapter(self.adapter_name, self.address)
-            adapter.instrument.snapshot.return_value = {'parameters': self.snapshot}
+            adapter.instrument.snapshot.return_value = {'parameters': copy.deepcopy(self.snapshot)}
 
             self.assertEqual(adapter.instrument, m4i_mock())
             self.assertEqual(adapter.name, self.instrument_name)
             config = adapter.read()
 
-            expected_config = self.snapshot
+            expected_config = self.snapshot.copy()
             expected_config.pop('IDN')
             expected_config.pop('box_averages')
+            expected_config.pop('card_available_length')
             self.assertDictEqual(expected_config, config)

--- a/src/tests/unittests/configuration_helper/adapters/test_s5i_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_s5i_instrument_adapter.py
@@ -85,7 +85,7 @@ class TestS5iInstrumentAdapter(unittest.TestCase):
 
     def test_apply_config(self):
         with patch('qilib.configuration_helper.adapters.spi_rack_instrument_adapter.SPI_rack') as spi_mock, \
-                patch('qcodes.instrument_drivers.QuTech.S5i.S5i_module') as s5i_module_mock:
+                patch('qcodes_contrib_drivers.drivers.QuTech.S5i.S5i_module') as s5i_module_mock:
             address = 'spirack1_module3'
             adapter_name = 'S5iInstrumentAdapter'
             instrument_name = '{0}_{1}'.format(adapter_name, address)
@@ -113,7 +113,7 @@ class TestS5iInstrumentAdapter(unittest.TestCase):
 
     def test_read_config(self):
         with patch('qilib.configuration_helper.adapters.spi_rack_instrument_adapter.SPI_rack') as spi_mock, \
-                patch('qcodes.instrument_drivers.QuTech.S5i.S5i_module') as s5i_module_mock:
+                patch('qcodes_contrib_drivers.drivers.QuTech.S5i.S5i_module') as s5i_module_mock:
             address = 'spirack1_module3'
             SerialPortResolver.serial_port_identifiers = {'spirack1': 'COMnumber_test'}
             s5i_adapter = InstrumentAdapterFactory.get_instrument_adapter('S5iInstrumentAdapter', address)
@@ -126,7 +126,7 @@ class TestS5iInstrumentAdapter(unittest.TestCase):
 
             identity = 'IDN'
             mock_config[identity] = 'version_test'
-            mocked_snapshot = {'name': 'some_s5i', 'parameters': mock_config}
+            mocked_snapshot = {'name': 'some_s5i', 'parameters': mock_config.copy()}
             s5i_adapter.instrument.snapshot = MagicMock(return_value=mocked_snapshot)
 
             config = s5i_adapter.read()


### PR DESCRIPTION
- Changed instrument adapter instrument with QCoDeS driver to imports via the `qcodes_contrib_drivers`.
- Apply the filter on the snapshot before checking of none value parameters.