### PR TITLE
add limit argument to StorageMemory

### DIFF
--- a/src/qilib/utils/storage/memory.py
+++ b/src/qilib/utils/storage/memory.py
@@ -68,16 +68,19 @@ class StorageMemory(StorageInterface):
 
     @staticmethod
     def _retrieve_nodes_from_dict_by_tag(dictionary: Dict[str, Any],
-                                         tag: TagType) -> TagType:
+                                         tag: TagType, limit: int = 0) -> TagType:
         if len(tag) == 0:
-            return list(dictionary.keys())
+            results = list(dictionary.keys())
+            if limit > 0:
+                results = results[:limit]
+            return results
         tag_prefix = tag[0]
         if tag_prefix not in dictionary:
             raise NoDataAtKeyError(tag)
         if isinstance(dictionary[tag_prefix], StorageMemory.__Leaf):
             raise NoDataAtKeyError(tag)
 
-        return StorageMemory._retrieve_nodes_from_dict_by_tag(dictionary[tag_prefix], tag[1:])
+        return StorageMemory._retrieve_nodes_from_dict_by_tag(dictionary[tag_prefix], tag[1:], limit=limit)
 
     @staticmethod
     def _store_value_to_dict_by_tag(dictionary: Dict[str, Any], tag: TagType, value: Any,
@@ -117,9 +120,9 @@ class StorageMemory(StorageInterface):
         child_tags = sorted(child_tags)
         return tag + [child_tags[-1]]
 
-    def list_data_subtags(self, tag: TagType) -> TagType:
+    def list_data_subtags(self, tag: TagType, limit: int = 0) -> TagType:
         try:
-            tags: TagType = self._retrieve_nodes_from_dict_by_tag(self._data, tag)
+            tags: TagType = self._retrieve_nodes_from_dict_by_tag(self._data, tag, limit=limit)
         except NoDataAtKeyError:
             return []
         return list(tags)

--- a/src/tests/unittests/utils/storage/test_storage_memory.py
+++ b/src/tests/unittests/utils/storage/test_storage_memory.py
@@ -68,9 +68,9 @@ class TestStorageMemory(unittest.TestCase):
     def test_list_subtags_limit(self):
         self.storage.save_data('1', ['a', '1'])
         self.storage.save_data('1', ['a', '2'])
-        tags = self.storage.list_data_subtags(['a'], limit = 0)
+        tags = self.storage.list_data_subtags(['a'], limit=0)
         self.assertEqual(tags, ['1', '2'])
-        tags = self.storage.list_data_subtags(['a'], limit = 1)
+        tags = self.storage.list_data_subtags(['a'], limit=1)
         self.assertEqual(tags, ['1'])
 
     def test_save_load(self):
@@ -158,4 +158,3 @@ class TestStorageMemory(unittest.TestCase):
 
         self.assertRaises(NodeDoesNotExistsError, self.storage.update_individual_data, 42, ['data', str(3000)], 'a')
         self.assertRaises(NodeDoesNotExistsError, self.storage.update_individual_data, 42, ['data3000'], 'a')
-

--- a/src/tests/unittests/utils/storage/test_storage_memory.py
+++ b/src/tests/unittests/utils/storage/test_storage_memory.py
@@ -65,6 +65,14 @@ class TestStorageMemory(unittest.TestCase):
         results = self.storage.list_data_subtags(['1a', '2', '3'])
         self.assertEqual(results, [])
 
+    def test_list_subtags_limit(self):
+        self.storage.save_data('1', ['a', '1'])
+        self.storage.save_data('1', ['a', '2'])
+        tags = self.storage.list_data_subtags(['a'], limit = 0)
+        self.assertEqual(tags, ['1', '2'])
+        tags = self.storage.list_data_subtags(['a'], limit = 1)
+        self.assertEqual(tags, ['1'])
+
     def test_save_load(self):
         storage = self.storage
         storage.save_data((1, 2), ['aap'])


### PR DESCRIPTION
The limit argument allows the StorageMemory to be used in testing when mongodb is not available.