### PR TITLE
[INS-28] Pin mongomock version to pass unittests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,5 +67,5 @@ setup(name='qilib',
       install_requires=['spirack>=0.1.8', 'numpy', 'serialize', 'zhinst', 'pymongo',
                         'requests', 'qcodes', 'qcodes_contrib_drivers', 'dataclasses-json'],
       extras_require={
-          'dev': ['pytest>=3.3.1', 'coverage>=4.5.1', 'mongomock', 'mypy', 'pylint'],
+          'dev': ['pytest>=3.3.1', 'coverage>=4.5.1', 'mongomock==3.20.0', 'mypy', 'pylint'],
       })


### PR DESCRIPTION
We need to pin the version of mongomock until mongomock can handle custom TypeRegistry.