### PR TITLE
[INS-68] modify adapters for dependency injection

### DIFF
--- a/src/qilib/configuration_helper/adapters/ami430_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/ami430_instrument_adapter.py
@@ -18,7 +18,7 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER I
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import math
-from typing import Any, Optional
+from typing import Any, Optional, Type
 
 from qcodes.instrument_drivers.american_magnetics.AMI430 import AMI430
 
@@ -30,7 +30,8 @@ from qilib.utils.python_json_structure import PythonJsonStructure
 class AMI430InstrumentAdapter(ReadOnlyConfigurationInstrumentAdapter):
     """ Adapter for the AMI430 QCoDeS driver."""
 
-    def __init__(self, address: str, instrument_name: Optional[str] = None) -> None:
+    def __init__(self, address: str, instrument_name: Optional[str] = None,
+                 instrument_class: Optional[Type[AMI430]] = None) -> None:
         """ Instantiate a new AMI430 instrument adapter.
 
         Args:
@@ -40,7 +41,9 @@ class AMI430InstrumentAdapter(ReadOnlyConfigurationInstrumentAdapter):
         super().__init__(address)
         ip_and_port = address.split(':')
         name = instrument_name if instrument_name is not None else self.name
-        self._instrument: AMI430 = AMI430(name=name, address=ip_and_port[0], port=int(ip_and_port[1]))
+        if instrument_class is None:
+            instrument_class = AMI430
+        self._instrument: AMI430 = instrument_class(name=name, address=ip_and_port[0], port=int(ip_and_port[1]))
         self.field_variation_tolerance = 0.01
 
     def apply(self, config: PythonJsonStructure) -> None:

--- a/src/qilib/configuration_helper/adapters/d5a_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/d5a_instrument_adapter.py
@@ -17,7 +17,7 @@ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEM
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from typing import Any, Optional
+from typing import Any, Optional, Type
 
 from qcodes_contrib_drivers.drivers.QuTech.D5a import D5a
 
@@ -39,11 +39,14 @@ MV = True
 
 class D5aInstrumentAdapter(ReadOnlyConfigurationInstrumentAdapter, SpiModuleInstrumentAdapter):
 
-    def __init__(self, address: str, instrument_name: Optional[str] = None) -> None:
+    def __init__(self, address: str, instrument_name: Optional[str] = None,
+                 instrument_class: Optional[Type[D5a]] = None) -> None:
         super().__init__(address, instrument_name)
-        self._instrument: D5a = D5a(self._instrument_name, self._spi_rack, self._module_number, mV=MV,
-                                    inter_delay=INTER_DELAY,
-                                    reset_voltages=RESET_VOLTAGE, dac_step=DAC_STEP)
+        if instrument_class is None:
+            instrument_class = D5a
+        self._instrument: D5a = instrument_class(self._instrument_name, self._spi_rack, self._module_number, mV=MV,
+                                                 inter_delay=INTER_DELAY,
+                                                 reset_voltages=RESET_VOLTAGE, dac_step=DAC_STEP)
         if self._instrument.span3() != '4v bi' and self._instrument.span3() != '2v bi':
             raise SpanValueError(f'D5a instrument has span {self._instrument.span3()} unequal to "4v bi" or "2v bi"')
 

--- a/src/qilib/configuration_helper/adapters/f1d_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/f1d_instrument_adapter.py
@@ -17,7 +17,7 @@ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEM
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from typing import Optional
+from typing import Optional, Type
 
 from qcodes_contrib_drivers.drivers.QuTech.F1d import F1d
 
@@ -26,6 +26,9 @@ from qilib.configuration_helper.adapters.spi_module_instrument_adapter import Sp
 
 class F1dInstrumentAdapter(SpiModuleInstrumentAdapter):
 
-    def __init__(self, address: str, instrument_name: Optional[str] = None) -> None:
+    def __init__(self, address: str, instrument_name: Optional[str] = None,
+                 instrument_class: Optional[Type[F1d]] = None) -> None:
         super().__init__(address, instrument_name)
-        self._instrument: F1d = F1d(self._instrument_name, self._spi_rack, self._module_number)
+        if instrument_class is None:
+            instrument_class = F1d
+        self._instrument: F1d = instrument_class(self._instrument_name, self._spi_rack, self._module_number)

--- a/src/qilib/configuration_helper/adapters/hdawg8_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/hdawg8_instrument_adapter.py
@@ -17,7 +17,7 @@ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEM
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from typing import Optional
+from typing import Optional, Type
 
 from qcodes_contrib_drivers.drivers.ZurichInstruments.ZIHDAWG8 import ZIHDAWG8
 
@@ -26,9 +26,12 @@ from qilib.utils.python_json_structure import PythonJsonStructure
 
 
 class ZIHDAWG8InstrumentAdapter(CommonInstrumentAdapter):
-    def __init__(self, address: str, instrument_name: Optional[str] = None) -> None:
+    def __init__(self, address: str, instrument_name: Optional[str] = None,
+                 instrument_class: Optional[Type[ZIHDAWG8]] = None) -> None:
         super().__init__(address, instrument_name)
-        self._instrument: ZIHDAWG8 = ZIHDAWG8(self._instrument_name, address)
+        if instrument_class is None:
+            instrument_class = ZIHDAWG8
+        self._instrument: ZIHDAWG8 = instrument_class(self._instrument_name, address)
 
     def read(self, update: bool = True) -> PythonJsonStructure:
         return PythonJsonStructure(super().read(update))

--- a/src/qilib/configuration_helper/adapters/keithley_dmm6500_adapter.py
+++ b/src/qilib/configuration_helper/adapters/keithley_dmm6500_adapter.py
@@ -17,7 +17,7 @@ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEM
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from typing import Optional
+from typing import Optional, Type
 
 import requests
 from qcodes.instrument_drivers.tektronix.Keithley_6500 import Keithley_6500
@@ -27,13 +27,16 @@ from qilib.utils.python_json_structure import PythonJsonStructure
 
 
 class Keithley6500InstrumentAdapter(CommonInstrumentAdapter):
-    def __init__(self, address: str, instrument_name: Optional[str] = None) -> None:
+    def __init__(self, address: str, instrument_name: Optional[str] = None,
+                 instrument_class: Optional[Type[Keithley_6500]] = None) -> None:
         super().__init__(address, instrument_name)
         if address[0:5] == 'TCPIP':
             # Perform a http request to the instrument's IP address before opening the device to make sure any
             # stuck state is unstuck.
             self._send_request_to_instrument(address)
-        self._instrument: Keithley_6500 = Keithley_6500(self._instrument_name, address)
+        if instrument_class is None:
+            instrument_class = Keithley_6500
+        self._instrument: Keithley_6500 = instrument_class(self._instrument_name, address)
 
     def _filter_parameters(self, parameters: PythonJsonStructure) -> PythonJsonStructure:
         return parameters

--- a/src/qilib/configuration_helper/adapters/keysight_e8267d_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/keysight_e8267d_instrument_adapter.py
@@ -17,7 +17,7 @@ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEM
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from typing import Optional
+from typing import Optional, Type
 
 from qcodes_contrib_drivers.drivers.Keysight.Keysight_E8267D import Keysight_E8267D
 
@@ -28,9 +28,12 @@ from qilib.utils.python_json_structure import PythonJsonStructure
 class KeysightE8267DInstrumentAdapter(CommonInstrumentAdapter):
     """ Adapter for the Keysight E8267D vector source."""
 
-    def __init__(self, address: str, instrument_name: Optional[str] = None) -> None:
+    def __init__(self, address: str, instrument_name: Optional[str] = None,
+                 instrument_class: Optional[Type[Keysight_E8267D]] = None) -> None:
         super().__init__(address, instrument_name)
-        self._instrument: Keysight_E8267D = Keysight_E8267D(self._instrument_name, address)
+        if instrument_class is None:
+            instrument_class = Keysight_E8267D
+        self._instrument: Keysight_E8267D = instrument_class(self._instrument_name, address)
 
     def _filter_parameters(self, parameters: PythonJsonStructure) -> PythonJsonStructure:
         for values in parameters.values():

--- a/src/qilib/configuration_helper/adapters/m2j_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/m2j_instrument_adapter.py
@@ -17,7 +17,7 @@ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEM
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from typing import Optional
+from typing import Optional, Type
 
 from qcodes_contrib_drivers.drivers.QuTech.M2j import M2j
 
@@ -26,6 +26,9 @@ from qilib.configuration_helper.adapters.spi_module_instrument_adapter import Sp
 
 class M2jInstrumentAdapter(SpiModuleInstrumentAdapter):
 
-    def __init__(self, address: str, instrument_name: Optional[str] = None) -> None:
+    def __init__(self, address: str, instrument_name: Optional[str] = None,
+                 instrument_class: Optional[Type[M2j]] = None) -> None:
         super().__init__(address, instrument_name)
-        self._instrument: M2j = M2j(self._instrument_name, self._spi_rack, self._module_number)
+        if instrument_class is None:
+            instrument_class = M2j
+        self._instrument: M2j = instrument_class(self._instrument_name, self._spi_rack, self._module_number)

--- a/src/qilib/configuration_helper/adapters/m4i_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/m4i_instrument_adapter.py
@@ -17,7 +17,7 @@ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEM
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from typing import Optional
+from typing import Any, Optional, Type
 
 from qilib.configuration_helper.adapters.common_instrument_adapter import CommonInstrumentAdapter
 from qilib.utils.python_json_structure import PythonJsonStructure
@@ -26,7 +26,8 @@ from qilib.utils.python_json_structure import PythonJsonStructure
 class M4iInstrumentAdapter(CommonInstrumentAdapter):
     """ Adapter for the Spectrum M4i digitizer."""
 
-    def __init__(self, address: str, instrument_name: Optional[str] = None, instrument_class=None) -> None:
+    def __init__(self, address: str, instrument_name: Optional[str] = None,
+                 instrument_class: Optional[Type[Any]] = None) -> None:
         from qcodes_contrib_drivers.drivers.Spectrum.M4i import M4i
         super().__init__(address, instrument_name)
         if instrument_class is None:

--- a/src/qilib/configuration_helper/adapters/m4i_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/m4i_instrument_adapter.py
@@ -26,10 +26,12 @@ from qilib.utils.python_json_structure import PythonJsonStructure
 class M4iInstrumentAdapter(CommonInstrumentAdapter):
     """ Adapter for the Spectrum M4i digitizer."""
 
-    def __init__(self, address: str, instrument_name: Optional[str] = None) -> None:
-        super().__init__(address, instrument_name)
+    def __init__(self, address: str, instrument_name: Optional[str] = None, instrument_class=None) -> None:
         from qcodes_contrib_drivers.drivers.Spectrum.M4i import M4i
-        self._instrument: M4i = M4i(self._instrument_name, cardid=address)
+        super().__init__(address, instrument_name)
+        if instrument_class is None:
+            instrument_class = M4i
+        self._instrument: M4i = instrument_class(self._instrument_name, cardid=address)
         if self._instrument is not None:
             self._instrument.initialize_channels()
 

--- a/src/qilib/configuration_helper/adapters/s5i_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/s5i_instrument_adapter.py
@@ -17,7 +17,7 @@ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEM
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from typing import Optional
+from typing import Optional, Type
 
 from qcodes_contrib_drivers.drivers.QuTech.S5i import S5i
 
@@ -26,6 +26,9 @@ from qilib.configuration_helper.adapters.spi_module_instrument_adapter import Sp
 
 class S5iInstrumentAdapter(SpiModuleInstrumentAdapter):
 
-    def __init__(self, address: str, instrument_name: Optional[str] = None) -> None:
+    def __init__(self, address: str, instrument_name: Optional[str] = None,
+                 instrument_class: Optional[Type[S5i]] = None) -> None:
         super().__init__(address, instrument_name)
-        self._instrument: S5i = S5i(self._instrument_name, self._spi_rack, self._module_number)
+        if instrument_class is None:
+            instrument_class = S5i
+        self._instrument: S5i = instrument_class(self._instrument_name, self._spi_rack, self._module_number)

--- a/src/qilib/configuration_helper/adapters/spi_rack_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/spi_rack_instrument_adapter.py
@@ -18,6 +18,7 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER I
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 from spirack import SPI_rack
+from typing import Optional, Type
 
 from qilib.configuration_helper.instrument_adapter import InstrumentAdapter
 from qilib.utils.python_json_structure import PythonJsonStructure
@@ -25,9 +26,11 @@ from qilib.utils.python_json_structure import PythonJsonStructure
 
 class SpiRackInstrumentAdapter(InstrumentAdapter):
 
-    def __init__(self, address: str) -> None:
+    def __init__(self, address: str, instrument_class: Optional[Type[SPI_rack]] = None) -> None:
         super().__init__(address)
-        self._spi_rack: SPI_rack = SPI_rack(address, baud='115200', timeout=1)
+        if instrument_class is None:
+            instrument_class = SPI_rack
+        self._spi_rack: SPI_rack = instrument_class(address, baud='115200', timeout=1)
 
     @property
     def instrument(self) -> SPI_rack:

--- a/src/qilib/configuration_helper/adapters/uhfli_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/uhfli_instrument_adapter.py
@@ -17,7 +17,7 @@ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEM
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from typing import Optional
+from typing import Optional, Type
 
 import numpy as np
 from qcodes.instrument_drivers.ZI.ZIUHFLI import ZIUHFLI
@@ -27,9 +27,12 @@ from qilib.utils.python_json_structure import PythonJsonStructure
 
 
 class ZIUHFLIInstrumentAdapter(CommonInstrumentAdapter):
-    def __init__(self, address: str, instrument_name: Optional[str] = None) -> None:
+    def __init__(self, address: str, instrument_name: Optional[str] = None,
+                 instrument_class: Optional[Type[ZIUHFLI]] = None) -> None:
         super().__init__(address, instrument_name)
-        self._instrument: ZIUHFLI = ZIUHFLI(self._instrument_name, device_ID=address)
+        if instrument_class is None:
+            instrument_class = ZIUHFLI
+        self._instrument: ZIUHFLI = instrument_class(self._instrument_name, device_ID=address)
 
     def _filter_parameters(self, parameters: PythonJsonStructure) -> PythonJsonStructure:
         for values in parameters.values():


### PR DESCRIPTION
modified the adapters to receive an instrumet_class in order to facilitate the injection of mocked instruments in the LLS testing framework