### PR TITLE
[INS-70] Modify SpiModuleInstrumentAdapter to accept dependency injection

### DIFF
--- a/src/qilib/configuration_helper/adapters/d5a_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/d5a_instrument_adapter.py
@@ -21,6 +21,7 @@ from typing import Any, Optional, Type
 
 from qcodes_contrib_drivers.drivers.QuTech.D5a import D5a
 
+from qilib.configuration_helper.adapters.spi_rack_instrument_adapter import SpiRackInstrumentAdapter
 from qilib.configuration_helper.adapters.read_only_configuration_instrument_adapter import \
     ReadOnlyConfigurationInstrumentAdapter
 from qilib.configuration_helper.adapters.spi_module_instrument_adapter import SpiModuleInstrumentAdapter
@@ -40,8 +41,9 @@ MV = True
 class D5aInstrumentAdapter(ReadOnlyConfigurationInstrumentAdapter, SpiModuleInstrumentAdapter):
 
     def __init__(self, address: str, instrument_name: Optional[str] = None,
-                 instrument_class: Optional[Type[D5a]] = None) -> None:
-        super().__init__(address, instrument_name)
+                 instrument_class: Optional[Type[D5a]] = None,
+                 spi_rack_instrument_adapter_class: Optional[Type[SpiRackInstrumentAdapter]] = None) -> None:
+        super().__init__(address, instrument_name, spi_rack_instrument_adapter_class)
         if instrument_class is None:
             instrument_class = D5a
         self._instrument: D5a = instrument_class(self._instrument_name, self._spi_rack, self._module_number, mV=MV,

--- a/src/qilib/configuration_helper/adapters/f1d_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/f1d_instrument_adapter.py
@@ -21,14 +21,16 @@ from typing import Optional, Type
 
 from qcodes_contrib_drivers.drivers.QuTech.F1d import F1d
 
+from qilib.configuration_helper.adapters.spi_rack_instrument_adapter import SpiRackInstrumentAdapter
 from qilib.configuration_helper.adapters.spi_module_instrument_adapter import SpiModuleInstrumentAdapter
 
 
 class F1dInstrumentAdapter(SpiModuleInstrumentAdapter):
 
     def __init__(self, address: str, instrument_name: Optional[str] = None,
-                 instrument_class: Optional[Type[F1d]] = None) -> None:
-        super().__init__(address, instrument_name)
+                 instrument_class: Optional[Type[F1d]] = None,
+                 spi_rack_instrument_adapter_class: Optional[Type[SpiRackInstrumentAdapter]] = None) -> None:
+        super().__init__(address, instrument_name, spi_rack_instrument_adapter_class)
         if instrument_class is None:
             instrument_class = F1d
         self._instrument: F1d = instrument_class(self._instrument_name, self._spi_rack, self._module_number)

--- a/src/qilib/configuration_helper/adapters/m2j_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/m2j_instrument_adapter.py
@@ -21,14 +21,16 @@ from typing import Optional, Type
 
 from qcodes_contrib_drivers.drivers.QuTech.M2j import M2j
 
+from qilib.configuration_helper.adapters.spi_rack_instrument_adapter import SpiRackInstrumentAdapter
 from qilib.configuration_helper.adapters.spi_module_instrument_adapter import SpiModuleInstrumentAdapter
 
 
 class M2jInstrumentAdapter(SpiModuleInstrumentAdapter):
 
     def __init__(self, address: str, instrument_name: Optional[str] = None,
-                 instrument_class: Optional[Type[M2j]] = None) -> None:
-        super().__init__(address, instrument_name)
+                 instrument_class: Optional[Type[M2j]] = None,
+                 spi_rack_instrument_adapter_class: Optional[Type[SpiRackInstrumentAdapter]] = None) -> None:
+        super().__init__(address, instrument_name, spi_rack_instrument_adapter_class)
         if instrument_class is None:
             instrument_class = M2j
         self._instrument: M2j = instrument_class(self._instrument_name, self._spi_rack, self._module_number)

--- a/src/qilib/configuration_helper/adapters/s5i_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/s5i_instrument_adapter.py
@@ -21,14 +21,16 @@ from typing import Optional, Type
 
 from qcodes_contrib_drivers.drivers.QuTech.S5i import S5i
 
+from qilib.configuration_helper.adapters.spi_rack_instrument_adapter import SpiRackInstrumentAdapter
 from qilib.configuration_helper.adapters.spi_module_instrument_adapter import SpiModuleInstrumentAdapter
 
 
 class S5iInstrumentAdapter(SpiModuleInstrumentAdapter):
 
     def __init__(self, address: str, instrument_name: Optional[str] = None,
-                 instrument_class: Optional[Type[S5i]] = None) -> None:
-        super().__init__(address, instrument_name)
+                 instrument_class: Optional[Type[S5i]] = None,
+                 spi_rack_instrument_adapter_class: Optional[Type[SpiRackInstrumentAdapter]] = None) -> None:
+        super().__init__(address, instrument_name, spi_rack_instrument_adapter_class)
         if instrument_class is None:
             instrument_class = S5i
         self._instrument: S5i = instrument_class(self._instrument_name, self._spi_rack, self._module_number)

--- a/src/qilib/configuration_helper/adapters/spi_module_instrument_adapter.py
+++ b/src/qilib/configuration_helper/adapters/spi_module_instrument_adapter.py
@@ -18,7 +18,7 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER I
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import re
-from typing import Tuple, Optional, cast
+from typing import Tuple, Type, Optional, cast
 from spirack import SPI_rack
 from qilib.configuration_helper.serial_port_resolver import SerialPortResolver
 from qilib.configuration_helper.adapters.spi_rack_instrument_adapter import SpiRackInstrumentAdapter
@@ -29,7 +29,8 @@ from qilib.utils.python_json_structure import PythonJsonStructure
 
 class SpiModuleInstrumentAdapter(CommonInstrumentAdapter):
 
-    def __init__(self, address: str, instrument_name: Optional[str] = None) -> None:
+    def __init__(self, address: str, instrument_name: Optional[str] = None,
+                 spi_rack_instrument_adapter_class: Optional[Type[SpiRackInstrumentAdapter]] = None) -> None:
         """ The base instrument adapter for each SPI rack module.
 
         Each module is identified using the name of the spirack the module number. The address is
@@ -43,9 +44,11 @@ class SpiModuleInstrumentAdapter(CommonInstrumentAdapter):
         """
         super().__init__(address, instrument_name)
         identifier, self._module_number = SpiModuleInstrumentAdapter.__collect_settings(address)
+        if spi_rack_instrument_adapter_class is None:
+            spi_rack_instrument_adapter_class = SpiRackInstrumentAdapter
         adapter: SpiRackInstrumentAdapter = cast(SpiRackInstrumentAdapter,
-                                                 SerialPortResolver.get_serial_port_adapter('SpiRackInstrumentAdapter',
-                                                                                            identifier))
+                                                 SerialPortResolver.get_serial_port_adapter(
+                                                     spi_rack_instrument_adapter_class.__name__, identifier))
         self._spi_rack: SPI_rack = adapter.spi_rack
 
     def read(self, update: bool = True) -> PythonJsonStructure:


### PR DESCRIPTION
Modify SpiModuleInstrumentAdapter to accept injection of the SpiRackInstrumentAdapter for mocking purposes