### PR TITLE
Alternative implementation of StorageMongoDb

### DIFF
--- a/src/qilib/utils/storage/memory.py
+++ b/src/qilib/utils/storage/memory.py
@@ -183,10 +183,9 @@ class StorageMemory(StorageInterface):
         return subtags, data 
 
 if __name__ == '__main__':
-    import uuid
-    s = self = StorageMemory('test_database')# 'test'+str(uuid.uuid4()))
+    s = StorageMemory('test_database')# 'test'+str(uuid.uuid4()))
     
-    st=s.list_data_subtags('')
+    st=s.list_data_subtags([])
     assert st==[]
     s.query_data_tags(['b'])
 

--- a/src/qilib/utils/storage/memory.py
+++ b/src/qilib/utils/storage/memory.py
@@ -17,7 +17,7 @@ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEM
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, List, Tuple
 
 from qilib.utils.storage.interface import (NoDataAtKeyError,
                                            NodeAlreadyExistsError,
@@ -167,3 +167,35 @@ class StorageMemory(StorageInterface):
         self._validate_tag(tag)
         self._validate_field(field)
         StorageMemory._store_value_to_dict_by_tag(self._data, tag, self._serialize(data), field)
+
+    def query_data_tags(self, tag: TagType, limit: int = 0, fields : Optional[List[str]] = None) -> Tuple[List[Any], List[Any]]:
+        """ Query data by tag and return both the tags and data"""
+        self._validate_tag(tag)
+        subtags = self.list_data_subtags(tag, limit = limit)
+        
+        raw_data = [self.load_data(tag+[subtag]) for subtag in subtags]
+        if fields is None:
+            pass
+        else:
+            raw_data = [ {k: v for k,v in r.items() if k in fields} for r in raw_data]
+           
+        data  = self._unserialize((list(raw_data)))
+        return subtags, data 
+
+if __name__ == '__main__':
+    import uuid
+    s = self = StorageMemory('test_database')# 'test'+str(uuid.uuid4()))
+    
+    st=s.list_data_subtags('')
+    assert st==[]
+    s.query_data_tags(['b'])
+
+
+    for jj in range(5):
+        s.save_data({'i': jj, 'ii':-jj}, ['a', str(jj)])
+    tags, data = s.query_data_tags(['a'])
+    assert len(tags)==5
+    
+    s.save_data({'one': 1}, ['a', 'b', 'c'])
+ 
+

--- a/src/qilib/utils/storage/mongov2.py
+++ b/src/qilib/utils/storage/mongov2.py
@@ -539,7 +539,8 @@ class StorageMongoDb(StorageInterface):
         return data # type: ignore
 
 
-    def delete_tag(self, tag: TagType) -> None:
+    def delete_data(self, tag: TagType) -> None:
+        """ Remove data for the specified tag """
         result = self._collection.delete_one({qi_tag: tag})
         if result.deleted_count==0:
             raise NoDataAtKeyError('could not delete {tag}')
@@ -549,6 +550,7 @@ class StorageMongoDb(StorageInterface):
 if __name__ == '__main__':
     import uuid
     s = self= StorageMongoDb('test'+str(uuid.uuid4()))
+    self.storage=s
     s.save_data({'one': 1}, 'a.b.c.d.e')
     s.save_data(2, 'a.b.c.d.f')
     tag='a.b'

--- a/src/qilib/utils/storage/mongov2.py
+++ b/src/qilib/utils/storage/mongov2.py
@@ -253,7 +253,7 @@ class StorageMongoDb(StorageInterface):
 
         return self._collection.find_one({qi_tag: validated_tag})
 
-    def save_raw_document(self, data: Any, tag: TagType):
+    def save_raw_document(self, data: Any, tag: TagType) -> None:
         """ Save MongoDB document without encoding """
         validated_tag = self._validate_tag(tag)
 
@@ -558,7 +558,7 @@ class StorageMongoDb(StorageInterface):
             data  = self._unserialize(self._decode_data(list(data)))
         else:
             tags=[]; data=[]
-        return tags, data # type: ignore
+        return tags, data 
 
     def delete_data(self, tag: TagType) -> None:
         """ Remove data for the specified tag 

--- a/src/qilib/utils/storage/mongov2.py
+++ b/src/qilib/utils/storage/mongov2.py
@@ -199,7 +199,7 @@ class StorageMongoDb(StorageInterface):
         if not isinstance(tag, list) or not all(isinstance(item, str) for item in tag):
             raise TypeError(f'Tag {tag} should be a list of strings')
         if np.any(['.' in t for t in tag]):
-            raise Exception('. not allowed in tags')
+            raise Exception('. not allowed in tag components')
         return '.'.join(tag)
 
     @staticmethod
@@ -468,9 +468,11 @@ if __name__ == '__main__':
     print(l)
 
     # TODO: index based on qi_tag
-    # TODO: update and overwrite of documents
     # TODO: s.list_data_subtags([]) (for empty entries...)
     # TODO: s.list_data_subtags([]) -> returns everyting, but we only want to have the things with no dots...!?
+    # TODO: fields are both encoded and serialized. do we really need the serialization?
+    # TODO: bulk test, database conversion
+    
 # %%%
     # if len(tag) == 0:
     #             return list(map(itemgetter('tag'),

--- a/src/qilib/utils/storage/mongov2.py
+++ b/src/qilib/utils/storage/mongov2.py
@@ -192,7 +192,7 @@ class StorageMongoDb(StorageInterface):
         return self._unserialize(self._decode_data(self._retrieve_value_by_tag(validated_tag)))
 
     @staticmethod
-    def _validate_tag(tag: TagType) -> TagType:
+    def _validate_tag(tag: TagType) -> TagType: #type: ignore
         """ Assert that tag is a list of strings."""
         if isinstance(tag, str):
             tag = tag_separator.join(tag.split('.'))
@@ -202,7 +202,7 @@ class StorageMongoDb(StorageInterface):
             raise TypeError(f'Tag {tag} should be a list of strings')
         if np.any([tag_separator in t for t in tag]):
             raise Exception(f'{tag_separator} not allowed in tag components')
-        return tag_separator.join(tag)
+        return tag_separator.join(tag) 
 
     @staticmethod
     def _unpack_tag(tag: TagType) -> TagType:
@@ -254,7 +254,7 @@ class StorageMongoDb(StorageInterface):
         self._store_value_by_tag(tag, self._encode_data(self._serialize(data)),
                                  self._encode_field(self._serialize(field)))
 
-    def get_latest_subtag(self, tag: TagType) -> Optional[TagType]:
+    def get_latest_subtag(self, tag: TagType) -> Optional[TagType]:  #type: ignore
         """ Get the latest subtag
 
         Args:
@@ -266,9 +266,9 @@ class StorageMongoDb(StorageInterface):
         if len(child_tags) == 0:
             return None
 
-        return self._unpack_tag(tag) + [child_tags[0]]
+        return self._unpack_tag(tag) + [child_tags[0]] #type: ignore
 
-    def list_data_subtags(self, tag: TagType, limit: int = 0, return_full_tag = False) -> TagType:
+    def list_data_subtags(self, tag: TagType, limit: int = 0, return_full_tag = False) -> TagType: #type: ignore
         """ List subtags for the given tag. The number of subtags listed is based on the limit parameter (0 for
         listing all subtags)
 
@@ -296,7 +296,7 @@ class StorageMongoDb(StorageInterface):
                 c = self._collection.find({qi_tag: tag_query}, {'value': 0},  limit=limit,  sort=[(qi_tag, -1)])
                 tags = list(map(itemgetter(qi_tag), c)) 
                 
-                def sub_part(t):
+                def sub_part(t : str) -> str:
                     
                     r= t[len(validated_tag)+1:]
                     n=t[:len(validated_tag)+1] + r.split(tag_separator)[0]
@@ -453,7 +453,7 @@ class StorageMongoDb(StorageInterface):
 
         return data
 
-    def query_data(self, tag: TagType, limit: int = 0, fields = None) -> List[Any]:
+    def query_data(self, tag: TagType, limit: int = 0, fields : Optional[List[str]] = None) -> List[Any]:
         """ Query data by tag and return part of the results """
         validated_tag = self._validate_tag(tag)
         if validated_tag == '':
@@ -466,8 +466,8 @@ class StorageMongoDb(StorageInterface):
             selection = {f'value.{f}':1 for f in fields}
         c = self._collection.find({qi_tag: tag_query}, selection,  limit=limit,  sort=[(qi_tag, -1)])
         raw_data = list(map(itemgetter('value'), c))        
-        data = self._unserialize(self._decode_data(raw_data))
-        return data
+        data  = self._unserialize(self._decode_data(raw_data))
+        return data # type: ignore
 
 
 # %%
@@ -503,28 +503,10 @@ if __name__ == '__main__':
 if __name__ == '__main__':
     
     tag='mydata'
-    def query_data(self, tag: TagType, limit: int = 0, fields = None) -> List[Any]:
-
-        validated_tag = self._validate_tag(tag)
-        if validated_tag == '':
-                    tag_query = {'$regex': f'^[^{tag_separator}]*$'}
-        else:
-                    tag_query = {'$regex': f'^{validated_tag}{tag_separator}[^{tag_separator}]*$'}
-        if fields is None:
-            selection={'value': 1}
-        else:
-            selection = {f'value.{f}':1 for f in fields}
-        c = self._collection.find({qi_tag: tag_query}, selection,  limit=limit,  sort=[(qi_tag, -1)])
-        raw_data = list(map(itemgetter('value'), c))        
-        data = self._unserialize(self._decode_data(raw_data))
-        return data
     
-    results = query_data(self, tag)
+    results = s.query_data( tag)
     fields=['z']
-    results = query_data(self, tag, fields=fields)
-    print(results)
-    fields=['y']
-    results = query_data(self, tag, fields=fields)
+    results = s.query_data( tag, fields=fields)
     print(results)
 
     

--- a/src/qilib/utils/storage/mongov2.py
+++ b/src/qilib/utils/storage/mongov2.py
@@ -550,7 +550,6 @@ class StorageMongoDb(StorageInterface):
 if __name__ == '__main__':
     import uuid
     s = self= StorageMongoDb('test'+str(uuid.uuid4()))
-    self.storage=s
     s.save_data({'one': 1}, 'a.b.c.d.e')
     s.save_data(2, 'a.b.c.d.f')
     tag='a.b'

--- a/src/qilib/utils/storage/mongov2.py
+++ b/src/qilib/utils/storage/mongov2.py
@@ -283,8 +283,7 @@ class StorageMongoDb(StorageInterface):
         try:
             validated_tag = self._validate_tag(tag)
             if 0:
-                # efficienct, but not backwards compatible
-                
+                # efficienct, but not backwards compatible                
                 if validated_tag == '':
                     tag_query = {'$regex': f'^[^{tag_separator}]*$'}
                 else:
@@ -305,7 +304,7 @@ class StorageMongoDb(StorageInterface):
                     n=t[:len(validated_tag)+1] + r.split(tag_separator)[0]
                     return n
                 tags = [sub_part(t) for t in tags]                                    
-                tags = list(set(tags))
+                tags = sorted(list(set(tags)))[::-1]
         except NoDataAtKeyError:
             tags = []
 

--- a/src/qilib/utils/storage/mongov2.py
+++ b/src/qilib/utils/storage/mongov2.py
@@ -41,7 +41,7 @@ TagType = Union[str, List[str]]
 numpy_ndarray_type = npt.NDArray[Any]
 
 def encode_numpy_array(
-            array: numpy_ndarray_type) -> dict:
+            array: numpy_ndarray_type) -> Union[float, Dict[str, Any]]:
         """ Encode numpy array to store in database.
         
         Numpy scalars of floating point type are cast to Python float values.
@@ -53,7 +53,7 @@ def encode_numpy_array(
             The encoded array.
 
         """
-        if isinstance(array, np.float32, np.float64) and 1:
+        if isinstance(array, (np.float32, np.float64) ):
             return float(array)
         return {
             NumpyKeys.OBJECT: np.array.__name__,
@@ -539,7 +539,7 @@ class StorageMongoDb(StorageInterface):
         return data # type: ignore
 
 
-    def delete_tag(self, tag: TagType):
+    def delete_tag(self, tag: TagType) -> None:
         result = self._collection.delete_one({qi_tag: tag})
         if result.deleted_count==0:
             raise NoDataAtKeyError('could not delete {tag}')

--- a/src/qilib/utils/storage/mongov2.py
+++ b/src/qilib/utils/storage/mongov2.py
@@ -30,11 +30,9 @@ from pymongo.errors import ServerSelectionTimeoutError
 from qilib.data_set.mongo_data_set_io import MongoDataSetIO, NumpyKeys
 from qilib.utils.serialization import Serializer, serializer as _serializer
 from qilib.utils.storage.interface import (NoDataAtKeyError,
-                                           NodeAlreadyExistsError,
                                            StorageInterface,
                                            ConnectionTimeoutError)
-from qilib.utils.type_aliases import TagType
-
+TagType = Union[str, List[str]]
 
 class NumpyArrayCodec(TypeCodec):  # type: ignore
 
@@ -189,12 +187,12 @@ class StorageMongoDb(StorageInterface):
 
     def load_data(self, tag: TagType) -> Any:
 
-        tag = self._validate_tag(tag)
+        validated_tag = self._validate_tag(tag)
 
-        return self._unserialize(self._decode_data(self._retrieve_value_by_tag(tag)))
+        return self._unserialize(self._decode_data(self._retrieve_value_by_tag(validated_tag)))
 
     @staticmethod
-    def _validate_tag(tag: TagType) -> None:
+    def _validate_tag(tag: TagType) -> TagType:
         """ Assert that tag is a list of strings."""
         if isinstance(tag, str):
             tag = tag_separator.join(tag.split('.'))

--- a/src/qilib/utils/storage/mongov2.py
+++ b/src/qilib/utils/storage/mongov2.py
@@ -1,0 +1,480 @@
+"""Quantum Inspire library
+
+Copyright 2019 QuTech Delft
+
+qilib is available under the [MIT open-source license](https://opensource.org/licenses/MIT):
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+from operator import itemgetter
+from typing import Any, Optional, Union
+
+import numpy as np
+from bson import ObjectId
+from bson.codec_options import TypeCodec, CodecOptions, TypeRegistry
+from pymongo import MongoClient
+from pymongo.errors import ServerSelectionTimeoutError
+
+from qilib.data_set.mongo_data_set_io import MongoDataSetIO, NumpyKeys
+from qilib.utils.serialization import Serializer, serializer as _serializer
+from qilib.utils.storage.interface import (NoDataAtKeyError,
+                                           NodeAlreadyExistsError,
+                                           StorageInterface,
+                                           ConnectionTimeoutError)
+from qilib.utils.type_aliases import TagType
+
+
+class NumpyArrayCodec(TypeCodec):  # type: ignore
+
+    @property
+    def python_type(self) -> Any:
+        return np.ndarray
+
+    def transform_python(self, value: Any) -> Any:
+        return MongoDataSetIO.encode_numpy_array(value)
+
+    @property
+    def bson_type(self) -> Any:
+        return dict
+
+    def transform_bson(self, value: Any) -> Any:
+        if NumpyKeys.OBJECT in value and value[NumpyKeys.OBJECT] == np.array.__name__:
+            return MongoDataSetIO.decode_numpy_array(value)
+
+        return value
+
+
+qi_tag = '_tag'
+
+
+class StorageMongoDb(StorageInterface):
+    """Reference implementation of StorageInterface with an mongodb backend
+
+    Implements a storage tree in a MongoDB collection
+    Performance Note: Creating index(es) in mongodb will help improve query performance
+    eg: An index on (parent, tag) will improve the performance of queries in _retrieve_nodes_by_tag
+    """
+
+    def __init__(self, name: str, host: str = 'localhost', port: int = 27017, database: str = '',
+                 serializer: Union[Serializer, None] = None, connection_timeout: float = 30000) -> None:
+        """MongoDB implementation of storage class
+
+        See also: `StorageInterface`
+
+        Args:
+            name: Symbolic name for the storage instance.
+            host: MongoDB host
+            port: MongoDB port
+            database: The database to use, if empty the name of the storage is used
+            connection_timeout: How long to try to connect to database before raising an error in milliseconds
+        Raises:
+            StorageTimeoutError: If connection to database has not been established before connection_timeout is reached
+        """
+        super().__init__(name)
+
+        type_registry = TypeRegistry([NumpyArrayCodec()])
+        codec_options = CodecOptions(type_registry=type_registry)
+        self._client = MongoClient(host, port, serverSelectionTimeoutMS=connection_timeout)
+        self._check_server_connection(connection_timeout)
+        self._db = self._client.get_database(database or name, codec_options=codec_options)
+        self._collection = self._db.get_collection('storage')
+
+        if serializer is None:
+            serializer = _serializer
+        self._serialize = serializer.encode_data
+        self._unserialize = serializer.decode_data
+
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__} at 0x{id(self):x}: name {self._db.name}>'
+
+    def __str__(self) -> str:
+        return f'<{type(self).__name__}: name {self._db.name}>'
+
+    def _check_server_connection(self, timeout: float) -> None:
+        """ Check if connection has been established to database server."""
+        try:
+            self._client.server_info()
+        except ServerSelectionTimeoutError as e:
+            raise ConnectionTimeoutError(f'Failed to connect to Mongo database within {timeout} milliseconds') from e
+
+    def _retrieve_nodes_by_tag(self, tag: TagType, parent: ObjectId, document_limit: int = 0) -> TagType:
+        """Traverse the tree and list the children of a given tag
+
+        Args:
+            tag: The node tag
+            parent: The ObjectID of the node's parent
+            document_limit: Maximum number of documents to return. If set to zero there is no limit
+
+        Returns:
+            A list of names of the children
+        """
+        raise
+
+    def _retrieve_value_by_tag(self, tag: TagType, field: Optional[Union[str, int]] = None) -> Any:
+        """Traverse the tree and retrieves the value / field value of a given leaf tag
+        If the field is specified, it returns the value of the field instead of tag value
+        If the specified field does not exist, it will raise a NoDataAtKeyError
+
+        Args:
+            tag: The leaf tag
+            parent: The ObjectID of the leaf's parent
+            field: The field to be retrieved. Default value is none.
+
+        Returns:
+            Data held by the leaf. If field is provided, returns the value of the
+            field stored in the leaf
+
+        Raises:
+            NoDataAtKeyError: If a tag in Tag list does not exist
+            or if the field does not exist
+        """
+
+        if field is None:
+            doc = self._collection.find_one({qi_tag: tag})
+        else:
+            doc = self._collection.find_one({qi_tag: tag}, {f'value.{field}': 1})
+
+        if doc is None:
+            raise NoDataAtKeyError(f'Tag "{tag[0]}" cannot be found')
+        elif 'value' not in doc:
+            raise NoDataAtKeyError(f'Tag "{tag[0]}" is not a leaf')
+        else:
+            if field is None:
+                return doc['value']
+            elif field in doc['value']:
+                return doc['value'][field]
+            else:
+                raise NoDataAtKeyError(f'The field "{field}" does not exists')
+
+    def _store_value_by_tag(self, tag: TagType, data: Any,
+                            field: Optional[Union[str, int]] = None) -> None:
+        """ Store a value at a given tag. In case a field is specified, function will update the value of the
+        field with data. If the field does not already exists, the field will be created
+
+        Args:
+            tag: The tag
+            data: Data to store
+            field: (encoded?) Field to be updated. Default value is None
+
+        Raises:
+              NodeAlreadyExistsError: If a tag in Tag List is an unexpected node/leaf
+              NoDataAtKeyError:  If a tag in Tag List does not exist
+        """
+
+        doc = self._collection.find_one({qi_tag: tag})
+        if doc:
+            # update
+            if field is None:
+                self._collection.update_one({qi_tag: tag}, {'$set': {'value': data}})
+            else:
+                self._collection.update_one({qi_tag: tag}, {'$set': {'value.'+str(field): data}})
+
+        else:
+            self._collection.insert_one({qi_tag: tag, 'value': data})
+
+    def load_data(self, tag: TagType) -> Any:
+
+        tag = self._validate_tag(tag)
+
+        return self._unserialize(self._decode_data(self._retrieve_value_by_tag(tag)))
+
+    @staticmethod
+    def _validate_tag(tag: TagType) -> None:
+        """ Assert that tag is a list of strings."""
+        if isinstance(tag, str):
+            return tag
+
+        if not isinstance(tag, list) or not all(isinstance(item, str) for item in tag):
+            raise TypeError(f'Tag {tag} should be a list of strings')
+        if np.any(['.' in t for t in tag]):
+            raise Exception('. not allowed in tags')
+        return '.'.join(tag)
+
+    @staticmethod
+    def _unpack_tag(tag: str) -> TagType:
+        return tag.split('.')
+
+    def save_data(self, data: Any, tag: TagType) -> None:
+        tag = self._validate_tag(tag)
+        self._store_value_by_tag(tag, self._encode_data(self._serialize(data)))
+
+    def load_individual_data(self, tag: TagType, field: Union[str, int]) -> Any:
+        """ Retrieve an individual field value at a given tag
+
+            Args:
+                tag: The tag
+                field: Name of the individual field to be retrieved
+
+            Raises:
+                NoDataAtKeyError if the tag is empty
+
+            Returns:
+                Value of the field
+        """
+
+        self._validate_tag(tag)
+        self._validate_field(field)
+
+        if len(tag) == 0:
+            raise NoDataAtKeyError('Tag cannot be empty')
+
+        return self._unserialize(self._decode_data(
+            self._retrieve_value_by_tag(tag,  self._encode_field(self._serialize(field)))))
+
+    def update_individual_data(self, data: Any, tag: TagType, field: Union[str, int]) -> None:
+        """ Update an individual field at a given tag with the given data.
+        If the field does not exist, it will be created.
+
+            Args:
+                data: Data to update
+                tag: The tag
+                field: Name of the individual field to updated
+
+        """
+
+        self._validate_tag(tag)
+        self._validate_field(field)
+        self._store_value_by_tag(tag, self._encode_data(self._serialize(data)),
+                                 self._encode_field(self._serialize(field)))
+
+    def get_latest_subtag(self, tag: TagType) -> Optional[TagType]:
+        """ Get the latest subtag
+
+        Args:
+            tag: Tag to search from
+        Returns:
+            Latest subtag found among subtags or None if there are no subtags
+        """
+        child_tags = self.list_data_subtags(tag, limit=1)
+        if len(child_tags) == 0:
+            return None
+
+        return self._unpack_tag(tag) + [child_tags[0]]
+
+    def list_data_subtags(self, tag: TagType, limit: int = 0) -> TagType:
+        """ List subtags for the given tag. The number of subtags listed is based on the limit parameter (0 for
+        listing all subtags)
+
+        Args:
+            tag: Tag to search from
+            limit: Maximum number of subtags to return. If set to zero there is no limit
+        Returns:
+            List of subtags found, sorted in descending order
+        """
+        try:
+            vtag = self._validate_tag(tag)
+            xtag = {'$regex': f'^{vtag}\..*'}
+            c = self._collection.find({qi_tag: xtag}, {'value': 0},     limit=document_limit,  sort=[('tag', -1)])
+            tags = list(map(itemgetter(qi_tag), c))
+
+        except NoDataAtKeyError:
+            tags = []
+
+        return tags
+
+    def search(self, query: str) -> Any:
+        raise NotImplementedError()
+
+    def tag_in_storage(self, tag: TagType) -> bool:
+        doc = self._collection.find_one({qi_tag: tag}, {'value': 0})
+        if doc is None:
+            return False
+        else:
+            return True
+
+    @staticmethod
+    def _encode_field(field: Union[int, str]) -> str:
+        """Encodes a field value. A field can be an individual key in a structure like dict which is to be
+        read or updated
+
+        Args:
+            field: An integer or a string
+
+        Returns:
+            Encoded value for the field in string format
+
+        """
+
+        return StorageMongoDb._encode_int(field) if isinstance(field, int) \
+            else field
+
+    @staticmethod
+    def _encode_int(value: int) -> str:
+        """Encodes an int value to a string
+
+        Args:
+            value: An integer
+
+        Returns:
+            An encoded integer
+        """
+
+        return f'_integer[{value}]'
+
+    @staticmethod
+    def _is_encoded_int(value: str) -> bool:
+        """Checks if the given value is a properly encoded integer
+
+        Args:
+            value: The encoded value
+
+        Returns:
+            True if an integer can be decoded, False otherwise
+        """
+
+        if not value.startswith('_integer[') or not value.endswith(']'):
+            return False
+
+        value = value[len('_integer['):-1]
+        return value[1:].isdigit() if value.startswith('-') else value.isdigit()
+
+    @staticmethod
+    def _decode_int(value: str) -> int:
+        """Parses an integer from the encoded value
+
+        Args:
+            value: The encoded integer
+
+        Returns:
+            The decoded integer
+        """
+
+        if not StorageMongoDb._is_encoded_int(value):
+            raise ValueError()
+
+        return int(value[len('_integer['):-1])
+
+    @staticmethod
+    def _encode_data(data: Any) -> Any:
+        """Recursively encode the data and apply dot replacement and integer encoding on the keys
+
+        Args:
+            data: The data
+        Returns:
+            The transformed data
+        """
+
+        if isinstance(data, dict):
+            return {
+                (StorageMongoDb._encode_int(key) if isinstance(key, int) else key): StorageMongoDb._encode_data(value)
+                for key, value in data.items()
+            }
+
+        elif isinstance(data, list):
+            return [StorageMongoDb._encode_data(item) for item in data]
+
+        return data
+
+    @staticmethod
+    def _decode_data(data: Any) -> Any:
+        """Recursively decode the data and apply dot replacement and integer decoding on the keys
+
+        Args:
+            data: The data
+        Returns:
+            The transformed data
+        """
+
+        if isinstance(data, dict):
+            return {
+                StorageMongoDb._decode_int(key)
+                if StorageMongoDb._is_encoded_int(key) else key: StorageMongoDb._decode_data(value)
+                for key, value in data.items()
+            }
+
+        elif isinstance(data, list):
+            return [StorageMongoDb._decode_data(item) for item in data]
+
+        return data
+
+
+"""
+Improvements:
+    
+    - Much less code
+    - No . encoding any more
+    - More efficient retrieval of subtags (no tree traversal)
+    - Tags can be entered in compact notation 'x.y.z'
+    - Multiple subfield retrieval?
+"""
+
+# %%
+if __name__ == '__main__':
+    s = StorageMongoDb('test6')
+
+    self = s
+
+    tag = 'multi'
+    for ii in range(4):
+        s.save_data(ii, tag)
+    assert s.load_data(tag) == 3
+
+    assert s.tag_in_storage(tag)
+
+    #parent = self._collection.insert_one({'test': '.', 'tag': 'tag'}).inserted_id
+    #parent = self._collection.insert_one({'test': '.', '\\u002e': 'tag'}).inserted_id
+    #parent = self._collection.insert_one({'test': '.', '.': 'dot tag'}).inserted_id
+
+    s.save_data({'one': np.array([1, 2, 4.])}, ['numpy'])
+    s.save_data({0: 'integer'}, ['0'])
+
+    s.list_data_subtags([])
+    s.save_data({'dot.field.dot': '.'}, ['dot_in_field'])
+    s.save_data({'one': 1, 'list': [1, 'a', 'c'], 'dict': {'a+b': 'c'}}, ['a', 'b', 'c'])
+
+    tag = 'a.b.c'
+    only_field = s.load_individual_data(tag, field='list')
+
+    s.update_individual_data([], tag, field='list')
+    only_field = s.load_individual_data(tag, field='list')
+
+    s.save_data({'one': 1}, 'st.x')
+    s.save_data({'no please': 2}, 'no.st.y')
+    for t in ['st.x', 'st.y.sub', 'st.z']:
+        s.save_data({'t': t}, t)
+    s.save_data({'one': np.array([1, 2, 4.])}, 'st.z')
+    tag = ['st', 'x']
+    doc = s.load_data(tag)
+    print(f'got data for {tag}: {doc}')
+
+    print(s.list_data_subtags('st'))
+    print(s.list_data_subtags('st.y'))
+
+    s.get_latest_subtag('st')
+
+    tag = 'numpy'
+    tag = self._validate_tag(tag)
+# %%
+if __name__ == '__main__':
+    tag = 'st.y'
+    document_limit = 100
+    xtag = '/^ma/'
+    vtag = self._validate_tag(tag)
+    xtag = {'$regex': f'^{vtag}\..*'}
+    c = self._collection.find({qi_tag: xtag}, {'value': 0},     limit=document_limit,       sort=[('tag', -1)])
+    l = list(map(itemgetter(qi_tag), c))
+    print(l)
+
+    # TODO: index based on qi_tag
+    # TODO: update and overwrite of documents
+    # TODO: s.list_data_subtags([]) (for empty entries...)
+    # TODO: s.list_data_subtags([]) -> returns everyting, but we only want to have the things with no dots...!?
+# %%%
+    # if len(tag) == 0:
+    #             return list(map(itemgetter('tag'),
+    #                             self._collection.find({'parent': parent, 'tag': {'$exists': True}},
+    #                                                   {'value': 0},
+    #                                                   limit=document_limit,
+    #                                                   sort=[('tag', -1)])))

--- a/src/qilib/utils/storage/mongov2.py
+++ b/src/qilib/utils/storage/mongov2.py
@@ -563,8 +563,6 @@ class StorageMongoDb(StorageInterface):
         data  = self._unserialize(self._decode_data(list(data)))
         return tags, data # type: ignore
 
->>>>>>> 7455426... add method to query data and return tags
-
     def delete_data(self, tag: TagType) -> None:
         """ Remove data for the specified tag 
 

--- a/src/tests/unittests/utils/storage/test_storage_mongov2.py
+++ b/src/tests/unittests/utils/storage/test_storage_mongov2.py
@@ -13,8 +13,6 @@ from qilib.utils.storage.mongov2 import NumpyArrayCodec
 from abc import ABC
 from typing import Any
 
-
-
 class DummyStorage(StorageMongoDb, ABC):
 
     def __init__(self, name, **kwargs):
@@ -26,7 +24,7 @@ class DummyStorage(StorageMongoDb, ABC):
 
 class TestStorageMongo(unittest.TestCase):
     def setUp(self) -> None:
-        with patch('qilib.utils.storage.mongo.MongoClient', return_value=MongoClient()):
+        with patch('qilib.utils.storage.mongov2.MongoClient', return_value=MongoClient()):
             self.storage = StorageMongoDb('test')
             self.test_data = [10, 3.14, 'string', {'a': 1, 'b': 2}, [1, 2], [1, [2, 3]], {'test': {'test': 2}},
                               {'tuple': (1, 2, 3, 4, 5)}, (1, 2, 3, 4, 5), (1, 2, {'he.llo': 'world'}),
@@ -128,6 +126,11 @@ class TestStorageMongo(unittest.TestCase):
 
     def test_load(self):
         self.assertRaises(NoDataAtKeyError, self.storage.load_data, [])
+
+    def test_list_subtags(self):
+        self.storage.save_data(1, 'a.b.c.d')
+        results = self.storage.list_data_subtags('a.b')
+        self.assertEqual(results, ['c'])
 
     def test_list_subtags(self):
         results = self.storage.list_data_subtags(['nodata'])

--- a/src/tests/unittests/utils/storage/test_storage_mongov2.py
+++ b/src/tests/unittests/utils/storage/test_storage_mongov2.py
@@ -110,11 +110,6 @@ class TestStorageMongo(unittest.TestCase):
         t = self.storage.datetag_part(dt)
         self.assertEqual(t, '2019-02-18T13:37:00.000023')
 
-    # def test_node_overwrite(self):
-    #     storage = self.storage
-    #     storage.save_data((1, 2), ['aap', 'noot'])
-    #     self.assertRaises(NodeAlreadyExistsError, storage.save_data, 'mies', ['aap'])
-
     def test_leaf_overwrite(self):
         storage = self.storage
         storage.save_data('over', ['aap', 'noot'])
@@ -129,7 +124,7 @@ class TestStorageMongo(unittest.TestCase):
     def test_load(self):
         self.assertRaises(NoDataAtKeyError, self.storage.load_data, [])
 
-    def test_list_subtags(self):
+    def test_list_subtags_str(self):
         self.storage.save_data(1, 'a.b.c.d')
         results = self.storage.list_data_subtags('a.b')
         self.assertEqual(results, ['c'])
@@ -165,6 +160,7 @@ class TestStorageMongo(unittest.TestCase):
         storage = self.storage
         storage.save_data('x', 'aapjes.noot')
         result = storage.load_data(['aapjes', 'noot'])
+        self.assertEqual(result, 'x')
 
     def test_save_load(self):
         storage = self.storage
@@ -334,9 +330,6 @@ class TestStorageMongo(unittest.TestCase):
                 'new.with.dot': 'new.key.with.dot'
             }
         }
-        # self.assertRaises(NodeAlreadyExistsError,
-        #                  self.storage.update_individual_data,
-        #                  test_dict, ['system'], 1)
 
         self.assertRaises(NoDataAtKeyError,
                           self.storage.update_individual_data,
@@ -345,10 +338,6 @@ class TestStorageMongo(unittest.TestCase):
         self.assertRaises(NoDataAtKeyError,
                           self.storage.update_individual_data,
                           test_dict, ['something', 'another'], 1)
-
-        # self.assertRaises(NodeAlreadyExistsError,
-        #                   self.storage.update_individual_data,
-        #                   test_dict, tag + ['extra'], 'a key')
 
         self.assertRaises(TypeError,
                           self.storage.update_individual_data,

--- a/src/tests/unittests/utils/storage/test_storage_mongov2.py
+++ b/src/tests/unittests/utils/storage/test_storage_mongov2.py
@@ -464,6 +464,14 @@ class TestStorageMongo(unittest.TestCase):
         self.assertIn('.', data[0])
         self.assertListEqual(data, list_of_strings_with_dots)
 
+    def test_list_subtags_order(self):
+        self.storage.save_data('test', ['hello', 'world'])      
+        self.storage.save_data('test', ['hello', 'planet'])
+        self.storage.save_data('test', ['hello', 'universe'])
+        self.storage.save_data('test', ['hello', 'galaxy'])
+        results = self.storage.list_data_subtags(['hello'], 2)
+        self.assertEqual(results, ['world', 'universe'])
+        
 if __name__ == '__main__':
     unittest.main()
 
@@ -489,6 +497,29 @@ if __name__ == '__main__':
         }
         
         results = self.storage.list_data_subtags(['nodata'])
+
+        # results = self.storage.list_data_subtags(['1'])
+        # self.assertEqual(results, [])
+
+        # results = self.storage.list_data_subtags(['1a', '2', '3'])
+        # self.assertEqual(results, [])
+
+        self.storage.save_data('test', ['hello', 'world'])
+        results = self.storage.list_data_subtags(['hello'])
+        #self.assertEqual(results, ['world'])
+
+        self.storage.save_data('test', ['hello', 'planet'])
+        self.storage.save_data('test', ['hello', 'universe'])
+        self.storage.save_data('test', ['hello', 'galaxy'])
+        results = self.storage.list_data_subtags(['hello'])
+        self.assertEqual(len(results), 4)
+        results = self.storage.list_data_subtags(['hello'], 2)
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0], 'world')
+        self.assertEqual(results[1], 'universe')
+        
+        
+        results = self.storage.list_data_subtags(['nodata'])
         self.assertEqual(results, [])
         self.storage.save_data('1', ['1'])
         results = self.storage.list_data_subtags(['1', 'nodata'])
@@ -500,16 +531,10 @@ if __name__ == '__main__':
         results = self.storage.list_data_subtags(['1a', '2', '3'])
         self.assertEqual(results, [])
        
-        self.storage.save_data('test', ['hello', 'world'])
-        results = self.storage.list_data_subtags(['hello'])
-        self.assertEqual(results, ['world'])
-       
+        self.storage.save_data('test', ['hello', 'world'])      
         self.storage.save_data('test', ['hello', 'planet'])
         self.storage.save_data('test', ['hello', 'universe'])
         self.storage.save_data('test', ['hello', 'galaxy'])
-        tag=['hello']
-        results = self.storage.list_data_subtags(tag)
-        self.assertEqual(len(results), 4)
         results = self.storage.list_data_subtags(['hello'], 2)
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0], 'world')

--- a/src/tests/unittests/utils/storage/test_storage_mongov2.py
+++ b/src/tests/unittests/utils/storage/test_storage_mongov2.py
@@ -1,0 +1,573 @@
+import datetime
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+from bson import BSON
+from bson.codec_options import TypeRegistry, CodecOptions
+from mongomock import MongoClient
+
+from qilib.utils.storage.mongov2 import StorageMongoDb
+from qilib.utils.storage.interface import NoDataAtKeyError, NodeAlreadyExistsError, ConnectionTimeoutError
+from qilib.utils.storage.mongov2 import NumpyArrayCodec
+from abc import ABC
+from typing import Any
+
+
+
+class DummyStorage(StorageMongoDb, ABC):
+
+    def __init__(self, name, **kwargs):
+        """ Dummy storage used for testing."""
+        super().__init__(name, **kwargs)
+
+    def encode_serialize_data(self, data: Any) -> Any:
+        return self._encode_data(self._serialize(data))
+
+class TestStorageMongo(unittest.TestCase):
+    def setUp(self) -> None:
+        with patch('qilib.utils.storage.mongo.MongoClient', return_value=MongoClient()):
+            self.storage = StorageMongoDb('test')
+            self.test_data = [10, 3.14, 'string', {'a': 1, 'b': 2}, [1, 2], [1, [2, 3]], {'test': {'test': 2}},
+                              {'tuple': (1, 2, 3, 4, 5)}, (1, 2, 3, 4, 5), (1, 2, {'he.llo': 'world'}),
+                              {'int64': np.int64(3.)}]
+            self.test_individual_data = {
+                1: 'integer_value',
+                '1': 'string_value',
+                'dict': {
+                    1: 'another_integer_value',
+                    '1': {
+                        1: 'last_integer_value',
+                        'something.with.dot': 'another.key.with.dot'
+                    }
+                },
+                'something.with.dot': 'key.with.dot',
+                'something.else.with.dots': {
+                    'key.dot': 123
+                },
+                'something': {
+                    'with.dot': 'nested values',
+                    'with': {
+                        'dot': 123
+                    }
+                },
+                'li.st': ['is', {'a': 'list', 12: 34}],
+                'tu.ple': (1, 2, 'tuple', (1, 2, 3)),
+                'boolean_value': False
+            }
+            self.dummy_storage = DummyStorage('dummy')
+
+    def tearDown(self) -> None:
+        self.storage._collection.drop()
+        self.dummy_storage._collection.drop()
+
+    def test_repr(self):
+        s=str(self.storage)
+        self.assertTrue(s.startswith('<StorageMongoDb'))
+        self.assertIn(self.storage.name, s)
+        s=repr(self.storage)
+        self.assertIn(f'{id(self.storage):x}', s)
+        self.assertIn(self.storage.name, s)
+
+    def test_server_timeout(self):
+        error_msg = 'Failed to connect to Mongo database within 0.01 milliseconds$'
+        self.assertRaisesRegex(ConnectionTimeoutError, error_msg, StorageMongoDb, 'test', port=-1,
+                               connection_timeout=0.01)
+
+    def test_save_load_basic_data(self):
+        for index, value in enumerate(self.test_data):
+            self.storage.save_data(value, ['data', str(index)])
+        for index, value in enumerate(self.test_data):
+            value_loaded = self.storage.load_data(['data', str(index)])
+            self.assertEqual(value, value_loaded)
+
+    def test_encode_decode_numpy_data(self):
+        data = {'array': np.array([1, 2, 3])}
+
+        type_registry = TypeRegistry([NumpyArrayCodec()])
+        codec_options = CodecOptions(type_registry=type_registry)
+        encoded = BSON.encode(data, codec_options=codec_options)
+        decoded = BSON.decode(encoded, codec_options=codec_options)
+
+        self.assertIsInstance(decoded, type(data))
+        self.assertIn('array', decoded)
+        np.testing.assert_array_equal(data['array'], decoded['array'])
+
+    def test_tag_type(self):
+        self.assertRaises(TypeError, self.storage.load_data, 3)
+        self.assertRaises(TypeError, self.storage.load_data, True)
+
+    def test_search(self):
+        self.assertRaises(NotImplementedError, self.storage.search, None)
+
+    def test_datetag_implicit(self):
+        t = self.storage.datetag_part()
+        self.assertIsInstance(t, str)
+        self.assertRegex(t, r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}')
+
+    def test_datetag_explicit(self):
+        dt = datetime.datetime(2019, 2, 18, 13, 37, 0, 23)
+        t = self.storage.datetag_part(dt)
+        self.assertEqual(t, '2019-02-18T13:37:00.000023')
+
+    # def test_node_overwrite(self):
+    #     storage = self.storage
+    #     storage.save_data((1, 2), ['aap', 'noot'])
+    #     self.assertRaises(NodeAlreadyExistsError, storage.save_data, 'mies', ['aap'])
+
+    def test_leaf_overwrite(self):
+        storage = self.storage
+        storage.save_data('over', ['aap', 'noot'])
+        self.assertEqual(storage.load_data(['aap', 'noot']), 'over')
+        storage.save_data('overwrite', ['aap', 'noot'])
+        self.assertEqual(storage.load_data(['aap', 'noot']), 'overwrite')
+
+    def test_no_data(self):
+        self.assertRaises(NoDataAtKeyError, self.storage.load_data, ['nosuchdata'])
+        self.assertRaises(NoDataAtKeyError, self.storage.load_data, ['nonode', 'nosuchdata'])
+
+    def test_load(self):
+        self.assertRaises(NoDataAtKeyError, self.storage.load_data, [])
+
+    def test_list_subtags(self):
+        results = self.storage.list_data_subtags(['nodata'])
+        self.assertEqual(results, [])
+        self.storage.save_data('1', ['1'])
+        results = self.storage.list_data_subtags(['1', 'nodata'])
+        self.assertEqual(results, [])
+
+        results = self.storage.list_data_subtags(['1'])
+        self.assertEqual(results, [])
+
+        results = self.storage.list_data_subtags(['1a', '2', '3'])
+        self.assertEqual(results, [])
+
+        self.storage.save_data('test', ['hello', 'world'])
+        results = self.storage.list_data_subtags(['hello'])
+        self.assertEqual(results, ['world'])
+
+        self.storage.save_data('test', ['hello', 'planet'])
+        self.storage.save_data('test', ['hello', 'universe'])
+        self.storage.save_data('test', ['hello', 'galaxy'])
+        results = self.storage.list_data_subtags(['hello'])
+        self.assertEqual(len(results), 4)
+        results = self.storage.list_data_subtags(['hello'], 2)
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0], 'world')
+        self.assertEqual(results[1], 'universe')
+
+    def test_save_load_string_tags(self):
+        storage = self.storage
+        storage.save_data('x','aapjes.noot')        
+        result = storage.load_data(['aapjes', 'noot'])
+
+    def test_save_load(self):
+        storage = self.storage
+        storage.save_data((1, 2), ['aap'])
+        storage.save_data('x', ['aapjes', 'noot'])
+        storage.save_data('x2', ['aapjes', 'mies'])
+
+        result = storage.load_data(['aapjes', 'noot'])
+        self.assertEqual(result, 'x')
+        results = storage.list_data_subtags(['aapjes'])
+        self.assertIsInstance(results, list)
+        self.assertEqual(results, ['noot', 'mies'])
+
+        storage.save_data('x2', ['1', '2', '3'])
+        self.assertRaises(NoDataAtKeyError, storage.load_data, ['1', '2'])
+        results = storage.list_data_subtags(['1', '2'])
+        self.assertEqual(results, ['3'])
+
+    def test_save_with_wrong_tag_type(self):
+        self.assertRaises(TypeError, self.storage.save_data, None, 0)
+
+    def test_save_tag_mixed_list_raises_error(self):
+        error_msg = r"Tag \['bla', 5\] should be a list of strings"
+        self.assertRaisesRegex(TypeError, error_msg, self.storage.save_data, 'data', ['bla', 5])
+
+    def test_get_latest(self):
+        storage = self.storage
+        test_tags = [
+            '2018-05-04T09:14:21.418753',
+            '2018-05-04T09:14:22.789361',
+            '2018-05-04T09:16:42.230137',
+            '2018-05-05T16:03:11.927642',
+        ]
+        for index in range(len(test_tags)):
+            storage.save_data(index, ['times', test_tags[index]])
+        latest_tag = storage.get_latest_subtag(['times'])
+        self.assertEqual(len(latest_tag), 2)
+        self.assertEqual(storage.load_data(latest_tag), index)
+        tag = storage.get_latest_subtag(['nosuchtag'])
+        self.assertIsNone(tag)
+
+    def test_leaf_node_in_path(self):
+        self.storage.save_data('foo', ['foo', 'bar'])
+        result = self.storage.list_data_subtags(['foo', 'bar'])
+        self.assertListEqual(result, [])
+
+    def test_tag_in_storage(self):
+        tag_in_storage = self.storage.tag_in_storage(['some-other-tag'])
+        self.assertFalse(tag_in_storage)
+
+        self.storage.save_data('some-dat', ['some-other-tag'])
+        tag_in_storage = self.storage.tag_in_storage(['some-other-tag'])
+        self.assertTrue(tag_in_storage)
+
+    def test_store_keys_with_integer(self):
+        data = {1: 'key with integer'}
+        self.storage.save_data(data, ['data'])
+        self.assertEqual(data, self.storage.load_data(['data']))
+
+    def test_store_keys_with_negative_integer(self):
+        data = {-1: 'key with negative integer'}
+        self.storage.save_data(data, ['data'])
+        self.assertEqual(data, self.storage.load_data(['data']))
+
+    def test_store_keys_with_dots(self):
+        data = {'key.with': 'dots!'}
+        self.storage.save_data(data, ['data'])
+        self.assertEqual(data, self.storage.load_data(['data']))
+
+    def test_store_keys_with_integers_and_dots(self):
+        data = {
+            1: 'integer_value',
+            '1': 'string_value',
+            'dict': {
+                1: 'another_integer_value',
+                '1': {
+                    1: 'last_integer_value',
+                    'something.with.dot': 'another.key.with.dot'
+                }
+            },
+            'something.with.dot': 'key.with.dot',
+            'something.else.with.dots': {
+                'key.dot': 123
+            },
+            'something': {
+                'with.dot': 'nested values',
+                'with': {
+                    'dot': 123
+                }
+            },
+            'li.st': ['is', {'a': 'list', 12: 34}],
+            'tu.ple': (1, 2, 'tuple', (1, 2, 3))
+        }
+        self.storage.save_data(data, ['data'])
+        self.assertEqual(data, self.storage.load_data(['data']))
+
+    def test_is_encoded_int(self):
+        self.assertTrue(StorageMongoDb._is_encoded_int('_integer[1]'))
+
+    def test_is_encoded_int_negative(self):
+        self.assertTrue(StorageMongoDb._is_encoded_int('_integer[-1]'))
+
+    def test_is_encoded_int_error_format(self):
+        self.assertFalse(StorageMongoDb._is_encoded_int('_int[1]'))
+
+    def test_is_encoded_int_error_integer(self):
+        self.assertFalse(StorageMongoDb._is_encoded_int('_integer[helloworld]'))
+
+    def test_encode_int(self):
+        self.assertEqual(StorageMongoDb._encode_int(7), '_integer[7]')
+
+    def test_decode_int(self):
+        self.assertEqual(StorageMongoDb._decode_int('_integer[7]'), 7)
+
+    def test_decode_int_incorrect(self):
+        self.assertRaises(ValueError, StorageMongoDb._decode_int, '_int[7]')
+
+    # def test_encode_str(self):
+    #     self.assertEqual(StorageMongoDb._encode_str('hello.world'), 'hello\\u002eworld')
+
+    # def test_decode_str(self):
+    #     self.assertEqual(StorageMongoDb._decode_str('hello.world'), 'hello.world')
+
+    def test_update_individual_data(self):
+        tag = ['system', 'properties']
+        self.storage.save_data(self.test_individual_data, tag)
+        self.assertEqual(self.test_individual_data, self.storage.load_data(tag))
+
+        test_tuple = (1, 2, 3)
+        test_list = ['was', {'b': 'string', 24: 68}]
+        test_string = 'New.Key.with.dot'
+        test_dict = {
+            2: 'another_integer_value',
+            '2': {
+                2: 'last_integer_value',
+                'new.with.dot': 'new.key.with.dot'
+            }
+        }
+        test_array = np.array([4., 5.])
+
+        self.storage.update_individual_data(test_tuple, tag, 'something')
+        self.storage.update_individual_data(test_list, tag, 'li.st')
+        self.storage.update_individual_data(test_string, tag, 'something.with.dot')
+        self.storage.update_individual_data(test_dict, tag, 'dict')
+        self.storage.update_individual_data(test_dict, tag, 1)
+        self.storage.update_individual_data(True, tag, 'boolean_value')
+        self.storage.update_individual_data(test_array, tag, 'numpy.array')
+
+        data = self.storage.load_data(tag)
+
+        self.assertEqual(data['something'], test_tuple)
+        self.assertEqual(data['li.st'], test_list)
+        self.assertEqual(data['something.with.dot'], test_string)
+        self.assertEqual(data['dict'], test_dict)
+        self.assertEqual(data[1], test_dict)
+        self.assertEqual(data['boolean_value'], True)
+        np.testing.assert_array_equal(data['numpy.array'], test_array)
+
+    def test_update_individual_data_raises_error(self):
+        tag = ['system', 'properties']
+        self.storage.save_data(self.test_individual_data, tag)
+
+        test_dict = {
+            2: 'another_integer_value',
+            '2': {
+                2: 'last_integer_value',
+                'new.with.dot': 'new.key.with.dot'
+            }
+        }
+        #self.assertRaises(NodeAlreadyExistsError,
+        #                  self.storage.update_individual_data,
+        #                  test_dict, ['system'], 1)
+
+        self.assertRaises(NoDataAtKeyError,
+                          self.storage.update_individual_data,
+                          test_dict, ['system', 'something'], 1)
+
+        self.assertRaises(NoDataAtKeyError,
+                          self.storage.update_individual_data,
+                          test_dict, ['something', 'another'], 1)
+
+        # self.assertRaises(NodeAlreadyExistsError,
+        #                   self.storage.update_individual_data,
+        #                   test_dict, tag + ['extra'], 'a key')
+
+        self.assertRaises(TypeError,
+                          self.storage.update_individual_data,
+                          test_dict, tag, {'dict_as_field': 1})
+
+    def test_update_individual_data_with_new_key(self):
+        tag = ['system', 'properties']
+        self.storage.save_data(self.test_individual_data, tag)
+
+        test_dict = {
+            2: 'another_integer_value',
+            '2': {
+                2: 'last_integer_value',
+                'new.with.dot': 'new.key.with.dot'
+            }
+        }
+
+        test_string = 'hello'
+        test_int = 236
+
+        self.storage.update_individual_data(test_dict, tag, 'new key')
+        data = self.storage.load_individual_data(tag, 'new key')
+        self.assertEqual(test_dict, data)
+
+        self.storage.update_individual_data(test_string, tag, 42)
+        data = self.storage.load_individual_data(tag, 42)
+        self.assertEqual(test_string, data)
+
+        self.storage.update_individual_data(test_int, tag, 42)
+        data = self.storage.load_individual_data(tag, 42)
+        self.assertEqual(test_int, data)
+
+    def test_load_individual_data(self):
+        data = {
+            1: 'integer_value',
+            '1.1': 'string_value',
+            'something.dot': {'value': 273, 'unit': 'K'},
+            'boolean_value': False
+        }
+
+        tag = ['system', 'properties', 'level 2']
+        self.storage.save_data(data, tag)
+        self.assertEqual(data, self.storage.load_data(tag))
+
+        individual_data = self.storage.load_individual_data(tag, 1)
+        self.assertEqual(data[1], individual_data)
+
+        individual_data = self.storage.load_individual_data(tag, '1.1')
+        self.assertEqual(data['1.1'], individual_data)
+
+        individual_data = self.storage.load_individual_data(tag, 'something.dot')
+        self.assertEqual(data['something.dot'], individual_data)
+
+        individual_data = self.storage.load_individual_data(tag, 'boolean_value')
+        self.assertEqual(data['boolean_value'], individual_data)
+
+    def test_load_individual_data_raises_error(self):
+        data = {
+            1: 'integer_value',
+            '1.1': 'string_value',
+            'something.dot': {'value': 273, 'unit': 'K'}
+        }
+        tag = ['system', 'properties', 'level 2']
+        self.storage.save_data(data, tag)
+
+        self.assertRaises(NoDataAtKeyError,
+                          self.storage.load_individual_data,
+                          ['undefined tag'], 1)
+        self.assertRaises(NoDataAtKeyError,
+                          self.storage.load_individual_data,
+                          ['system'], 1)
+        self.assertRaises(NoDataAtKeyError,
+                          self.storage.load_individual_data,
+                          [], 1)
+        self.assertRaises(NoDataAtKeyError,
+                          self.storage.load_individual_data,
+                          ['system', 'new', 'another'], 1)
+
+    def test_load_individual_data_with_new_key(self):
+        data = {
+            1: 'integer_value',
+            '1.1': 'string_value',
+            'something.dot': {'value': 273, 'unit': 'K'}
+        }
+        tag = ['system', 'properties', 'level 2']
+        self.storage.save_data(data, tag)
+
+        self.assertRaises(NoDataAtKeyError,
+                          self.storage.load_individual_data,
+                          tag, 'something.dot.NEW')
+
+        self.assertRaises(NoDataAtKeyError,
+                          self.storage.load_individual_data,
+                          tag, 11)
+
+    def test_numpy_array_encoded_data(self):
+        np_array = np.array([10., 20., 30.])
+        data = self.dummy_storage.encode_serialize_data(np_array)
+        shape = data['__content__']['__shape__']
+
+        self.assertEqual(shape, [3])
+        self.assertIsInstance(shape[0], int)
+
+    def test_list_encoded_data(self):
+        list_of_integers = [42, 43, 44]
+        data = self.dummy_storage.encode_serialize_data(list_of_integers)
+
+        self.assertIsInstance(data[0], int)
+        self.assertEqual(data, list_of_integers)
+
+        list_of_strings_with_dots = ['hello.world', 'string.with.dots']
+        data = self.dummy_storage.encode_serialize_data(list_of_strings_with_dots)
+
+        self.assertNotIn('\\u002e', data[0])
+        self.assertIn('.', data[0])
+        self.assertListEqual(data, list_of_strings_with_dots)
+
+if __name__ == '__main__':
+    unittest.main()
+
+    def test_save_load(self):
+        import uuid
+        storage = StorageMongoDb('test'+str( uuid.uuid4()))
+        
+        
+        self = storage
+        self.storage=storage
+        self.test_individual_data = {
+            1: 'integer_value',            
+            'something.else.with.dots': {
+                'key.dot': 123
+            },
+            'something': {
+                'with.dot': 'nested values',
+                'with': {
+                    'dot': 123
+                }
+            },
+            
+        }
+        
+        results = self.storage.list_data_subtags(['nodata'])
+        self.assertEqual(results, [])
+        self.storage.save_data('1', ['1'])
+        results = self.storage.list_data_subtags(['1', 'nodata'])
+        self.assertEqual(results, [])
+       
+        results = self.storage.list_data_subtags(['1'])
+        self.assertEqual(results, [])
+       
+        results = self.storage.list_data_subtags(['1a', '2', '3'])
+        self.assertEqual(results, [])
+       
+        self.storage.save_data('test', ['hello', 'world'])
+        results = self.storage.list_data_subtags(['hello'])
+        self.assertEqual(results, ['world'])
+       
+        self.storage.save_data('test', ['hello', 'planet'])
+        self.storage.save_data('test', ['hello', 'universe'])
+        self.storage.save_data('test', ['hello', 'galaxy'])
+        tag=['hello']
+        results = self.storage.list_data_subtags(tag)
+        self.assertEqual(len(results), 4)
+        results = self.storage.list_data_subtags(['hello'], 2)
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0], 'world')
+        self.assertEqual(results[1], 'universe')
+         
+        storage.save_data('foo', ['foo', 'bar'])
+        storage.list_data_subtags(['foo', 'bar'])
+        
+        tag = ['system', 'properties2']
+        self.storage.save_data(self.test_individual_data, tag)
+        data = self.storage.load_data(tag)
+
+        test_dict = {
+            2: 'another_integer_value',
+            '2': {
+                2: 'last_integer_value',
+                'new.with.dot': 'new.key.with.dot'
+            }
+        }
+
+        test_string = 'hello'
+        test_int = 236
+
+        self.storage.update_individual_data(test_dict, tag, 'new key')
+        data = self.storage.load_individual_data(tag, 'new key')
+        self.assertEqual(test_dict, data)
+
+        self.storage.update_individual_data(test_string, tag, 42)
+        data = self.storage.load_individual_data(tag, 42)
+        self.assertEqual(test_string, data)
+
+        self.storage.update_individual_data(test_int, tag, 42)
+        data = self.storage.load_individual_data(tag, 42)
+        self.assertEqual(test_int, data)
+        
+        tag='xx'
+        storage.save_data(self.test_individual_data, tag)
+        storage.update_individual_data((1,2,3), tag, 'something')
+        r=storage.load_data(tag)
+        print(r)
+        
+        storage.save_data((1, 2), ['aap'])
+        storage.save_data('x', ['aapjes', 'noot'])
+        storage.save_data('x2', ['aapjes', 'mies'])
+
+        result = storage.load_data(['aapjes', 'noot'])
+        self.assertEqual(result, 'x')
+        results = storage.list_data_subtags(['aapjes'])
+        self.assertIsInstance(results, list)
+        self.assertEqual(results, ['noot', 'mies'])
+
+        storage.save_data('x2', ['1', '2', '3'])
+        self.assertRaises(NoDataAtKeyError, storage.load_data, ['1', '2'])
+        results = storage.list_data_subtags(['1', '2'])
+        self.assertEqual(results, ['3'])
+
+    def query_data(self):
+        for ii in range(4):
+            self.storage.save_data({'x': ii, 'y': (ii, str(ii)), 'z': np.array([np.random.rand()])}, ['mydata', str(ii)])
+    
+        tag ='mydata'
+        fields=['y']
+        results = self.query_data(tag, fields=fields)
+        self.assertEqual(len(results), 4)

--- a/src/tests/unittests/utils/storage/test_storage_mongov2.py
+++ b/src/tests/unittests/utils/storage/test_storage_mongov2.py
@@ -476,6 +476,23 @@ class TestStorageMongo(unittest.TestCase):
         self.storage.save_data({10: 'nofloat', 0: 'int'}, ['test'])
         value=self.storage.load_data(['test'])
         self.assertEqual(list(value.keys()), [10, 0])
+
+    def test_delete_data(self):
+    
+            self.storage.save_data(100, 'del')
+            self.storage.save_data(101, 'del')
+            self.assertTrue(self.storage.tag_in_storage('del'))
+            self.storage.delete_data('del')
+            self.assertFalse(self.storage.tag_in_storage('del'))
+
+    def test_query_data(self):
+        for ii in range(4):
+            self.storage.save_data({'x': ii, 'y': (ii, str(ii)), 'z': np.array([np.random.rand()])}, ['mydata', str(ii)])
+    
+        tag ='mydata'
+        fields=['y']
+        results = self.storage.query_data(tag, fields=fields)
+        self.assertEqual(len(results), 4)
         
 if __name__ == '__main__':
     unittest.main()
@@ -596,7 +613,7 @@ if __name__ == '__main__':
         results = storage.list_data_subtags(['1', '2'])
         self.assertEqual(results, ['3'])
 
-    def query_data(self):
+    def test_query_data(self):
         for ii in range(4):
             self.storage.save_data({'x': ii, 'y': (ii, str(ii)), 'z': np.array([np.random.rand()])}, ['mydata', str(ii)])
     
@@ -604,3 +621,13 @@ if __name__ == '__main__':
         fields=['y']
         results = self.query_data(tag, fields=fields)
         self.assertEqual(len(results), 4)
+
+    def test_delete_data(self):
+    
+            self.storage.save_data(100, 'del')
+            self.storage.save_data(101, 'del')
+            self.assertTrue(self.storage.tag_in_storage('del'))
+            self.storage.delete_data('del')
+            self.assertFalse(self.storage.tag_in_storage('del'))
+            
+

--- a/src/tests/unittests/utils/storage/test_storage_mongov2.py
+++ b/src/tests/unittests/utils/storage/test_storage_mongov2.py
@@ -471,6 +471,11 @@ class TestStorageMongo(unittest.TestCase):
         self.storage.save_data('test', ['hello', 'galaxy'])
         results = self.storage.list_data_subtags(['hello'], 2)
         self.assertEqual(results, ['world', 'universe'])
+
+    def test_int_keys_in_dict(self):        
+        self.storage.save_data({10: 'nofloat', 0: 'int'}, ['test'])
+        value=self.storage.load_data(['test'])
+        self.assertEqual(list(value.keys()), [10, 0])
         
 if __name__ == '__main__':
     unittest.main()

--- a/src/tests/unittests/utils/storage/test_storage_mongov2.py
+++ b/src/tests/unittests/utils/storage/test_storage_mongov2.py
@@ -485,6 +485,11 @@ class TestStorageMongo(unittest.TestCase):
         results = self.storage.query_data(tag, fields=fields)
         self.assertEqual(len(results), 4)
 
+    def test_regression_query_data_empty_database(self):
+
+        results = self.storage.query_data('')
+        self.assertEqual(len(results), 0)
+
     def test_str_tag(self):
         self.storage.save_data(100, 'a.b.c')
         value = self.storage.load_data(['a', 'b', 'c'])

--- a/src/tests/unittests/utils/storage/test_storage_mongov2.py
+++ b/src/tests/unittests/utils/storage/test_storage_mongov2.py
@@ -493,6 +493,13 @@ class TestStorageMongo(unittest.TestCase):
         fields=['y']
         results = self.storage.query_data(tag, fields=fields)
         self.assertEqual(len(results), 4)
+
+    def test_str_tag(self):
+            self.storage.save_data(100, 'a.b.c')
+            value = self.storage.load_data(['a', 'b', 'c'])
+            self.assertEqual(value, 100)
+            value = self.storage.load_data('a.b.c')
+            self.assertEqual(value, 100)
         
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is an alternative implementation of the `StorageMongoDB`. The implementation based on the [materialized path design](https://docs.mongodb.com/manual/tutorial/model-tree-structures-with-materialized-paths/). The main benefit is that it is much more efficient in loading small data than the original implementation and it allows for more efficient queries of series of data. (for small documents the improvement has been benchmarked as a factor 4)
  
- More efficient retrieval of subtags (no tree traversal)
- Tags can be entered in compact notation 'x.y.z'
- Multiple subfield retrieval implemented with `query_data`
- Data can be deleted with the `delete_data` method
```
import numpy as np
from qilib.utils.storage.mongov2 import StorageMongoDb

s = StorageMongoDb('p')
for ii in range(10):
        s.save_data({'x': ii, 'y': (ii, str(ii)), 'z': np.array([np.random.rand()])}, ['mydata', str(ii)])
results = s.query_data( tag, fields=['y', 'z'])
``` 
   
@QFer 