### PR TITLE
Add python 3.10 to CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,10 +62,11 @@ setup(name='qilib',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
-          'Programming Language :: Python :: 3.9'],
+          'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python :: 3.10'],
       license='Other/Proprietary License',
 
-      install_requires=['spirack>=0.1.8', 'numpy>=1.20', 'serialize', 'zhinst', 'pymongo',
+      install_requires=['spirack>=0.1.8', 'numpy>=1.20', 'serialize', 'pymongo',
                         'requests', 'qcodes', 'qcodes_contrib_drivers', 'dataclasses-json'],
       extras_require={
           'dev': ['pytest>=3.3.1', 'coverage>=4.5.1', 'mongomock==3.20.0', 'mypy', 'pylint', 'types-requests'],

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(name='qilib',
           'Programming Language :: Python :: 3.10'],
       license='Other/Proprietary License',
 
-      install_requires=['spirack>=0.1.8', 'numpy>=1.20', 'serialize', 'pymongo',
+      install_requires=['spirack>=0.1.8', 'numpy>=1.20', 'serialize', 'pymongo', 'zhinst;python_version<"3.10"', 
                         'requests', 'qcodes', 'qcodes_contrib_drivers', 'dataclasses-json'],
       extras_require={
           'dev': ['pytest>=3.3.1', 'coverage>=4.5.1', 'mongomock==3.20.0', 'mypy', 'pylint', 'types-requests'],

--- a/src/qilib/configuration_helper/adapters/__init__.py
+++ b/src/qilib/configuration_helper/adapters/__init__.py
@@ -1,3 +1,4 @@
+import sys
 from qilib.configuration_helper.adapters.common_instrument_adapter import CommonInstrumentAdapter
 from qilib.configuration_helper.adapters.read_only_configuration_instrument_adapter import ReadOnlyConfigurationInstrumentAdapter
 from qilib.configuration_helper.adapters.ami430_instrument_adapter import AMI430InstrumentAdapter
@@ -10,5 +11,6 @@ from qilib.configuration_helper.adapters.hdawg8_instrument_adapter import ZIHDAW
 from qilib.configuration_helper.adapters.m2j_instrument_adapter import M2jInstrumentAdapter
 from qilib.configuration_helper.adapters.m4i_instrument_adapter import M4iInstrumentAdapter
 from qilib.configuration_helper.adapters.s5i_instrument_adapter import S5iInstrumentAdapter
-from qilib.configuration_helper.adapters.uhfli_instrument_adapter import ZIUHFLIInstrumentAdapter
+if sys.version_info<(3, 10):
+    from qilib.configuration_helper.adapters.uhfli_instrument_adapter import ZIUHFLIInstrumentAdapter
 from qilib.configuration_helper.adapters.keysight_e8267d_instrument_adapter import KeysightE8267DInstrumentAdapter

--- a/src/qilib/configuration_helper/adapters/__init__.py
+++ b/src/qilib/configuration_helper/adapters/__init__.py
@@ -11,6 +11,6 @@ from qilib.configuration_helper.adapters.hdawg8_instrument_adapter import ZIHDAW
 from qilib.configuration_helper.adapters.m2j_instrument_adapter import M2jInstrumentAdapter
 from qilib.configuration_helper.adapters.m4i_instrument_adapter import M4iInstrumentAdapter
 from qilib.configuration_helper.adapters.s5i_instrument_adapter import S5iInstrumentAdapter
-if sys.version_info<(3, 10):
+if sys.version_info < (3, 10):
     from qilib.configuration_helper.adapters.uhfli_instrument_adapter import ZIUHFLIInstrumentAdapter
 from qilib.configuration_helper.adapters.keysight_e8267d_instrument_adapter import KeysightE8267DInstrumentAdapter

--- a/src/tests/unittests/configuration_helper/adapters/test_hdawg8_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_hdawg8_instrument_adapter.py
@@ -1,9 +1,11 @@
 import json
 import os
+import sys
 import unittest
 from unittest.mock import patch, MagicMock, call
 
-import zhinst
+if sys.version_info < (3, 10):    
+    import zhinst
 
 import qilib
 from qilib.configuration_helper import InstrumentAdapterFactory
@@ -69,6 +71,7 @@ class TestZIHDAWG8InstrumentAdapter(unittest.TestCase):
             "Unit": "None"
         }}
 
+    @unittest.skipIf(sys.version_info >= (3, 10), "zhinst not supported on python 3.10")
     def test_apply(self):
         with patch.object(zhinst.utils, 'create_api_session', return_value=3 * (MagicMock(),)) as daq, \
                 patch.object(qilib.configuration_helper.adapters.hdawg8_instrument_adapter.ZIHDAWG8,
@@ -125,6 +128,7 @@ class TestZIHDAWG8InstrumentAdapter(unittest.TestCase):
 
             hdawg_adapter.instrument.close()
 
+    @unittest.skipIf(sys.version_info >= (3, 10), "zhinst not supported on python 3.10")
     def test_full_node_tree(self):
         with patch.object(zhinst.utils, 'create_api_session', return_value=3 * (MagicMock(),)) as daq, \
                 open(self._node_tree_path) as node_tree, \
@@ -210,6 +214,7 @@ class TestZIHDAWG8InstrumentAdapter(unittest.TestCase):
             dawg.assert_has_calls([call().upload_sequence_program(1, 'program')])
             hdawg_adapter.instrument.close()
 
+    @unittest.skipIf(sys.version_info >= (3, 10), "zhinst not supported on python 3.10")
     def test_read_should_filter_nics(self):
         with patch.object(zhinst.utils, 'create_api_session', return_value=3 * (MagicMock(),)) as daq, \
                 open(self._node_tree_path) as node_tree, \

--- a/src/tests/unittests/configuration_helper/adapters/test_uhfli_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_uhfli_instrument_adapter.py
@@ -2,13 +2,15 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import numpy as np
-import zhinst
+if sys.version_info < (3, 10):    
+    import zhinst
 
 from qilib.configuration_helper import InstrumentAdapterFactory
 
 
 class TestZIUHFLIInstrumentAdapter(unittest.TestCase):
 
+    @unittest.skipIf(sys.version_info >= (3, 10), "zhinst not supported on python 3.10")
     def test_read_apply(self):
         with patch.object(zhinst.utils, 'create_api_session', return_value=3 * (MagicMock(),)):
             adapter = InstrumentAdapterFactory.get_instrument_adapter('ZIUHFLIInstrumentAdapter', 'dev4242')
@@ -38,6 +40,7 @@ class TestZIUHFLIInstrumentAdapter(unittest.TestCase):
 
         adapter.instrument.close()
 
+    @unittest.skipIf(sys.version_info >= (3, 10), "zhinst not supported on python 3.10")
     def test_int64_convert_to_int(self):
         with patch.object(zhinst.utils, 'create_api_session', return_value=3 * (MagicMock(),)):
             adapter = InstrumentAdapterFactory.get_instrument_adapter('ZIUHFLIInstrumentAdapter', 'dev4142')
@@ -60,6 +63,7 @@ class TestZIUHFLIInstrumentAdapter(unittest.TestCase):
 
         adapter.instrument.close()
 
+    @unittest.skipIf(sys.version_info >= (3, 10), "zhinst not supported on python 3.10")
     def test_filtered_parameters(self):
         with patch.object(zhinst.utils, 'create_api_session', return_value=3 * (MagicMock(),)):
             adapter = InstrumentAdapterFactory.get_instrument_adapter('ZIUHFLIInstrumentAdapter', 'dev4242')

--- a/src/tests/unittests/configuration_helper/adapters/test_uhfli_instrument_adapter.py
+++ b/src/tests/unittests/configuration_helper/adapters/test_uhfli_instrument_adapter.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import MagicMock, patch
-
+import sys
 import numpy as np
 if sys.version_info < (3, 10):    
     import zhinst


### PR DESCRIPTION
This adds support for python 3.10 by dropping support for the legacy `zhinst` on python >= 3.10